### PR TITLE
Add missing IAM policy document for EBS volume encryption with KMS CMK

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Below are links to various docs related to the customization and management of y
 | [aws_iam_policy_document.s3_crr_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.tfe_ec2_allow_cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.tfe_ec2_allow_cost_estimation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.tfe_ec2_allow_ebs_kms_cmk](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.tfe_ec2_allow_get_redis_password_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.tfe_ec2_allow_rds_kms_cmk](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.tfe_ec2_allow_redis_kms_cmk](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/iam.tf
+++ b/iam.tf
@@ -193,6 +193,25 @@ data "aws_iam_policy_document" "tfe_ec2_allow_get_redis_password_secret" {
   }
 }
 
+data "aws_iam_policy_document" "tfe_ec2_allow_ebs_kms_cmk" {
+  count = var.ebs_kms_key_arn != null ? 1 : 0
+
+  statement {
+    sid    = "TfeEc2AllowEbsKmsCmk"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:Encrypt",
+      "kms:DescribeKey",
+      "kms:GenerateDataKey",
+      "kms:GenerateDataKey*"
+    ]
+    resources = [
+      var.ebs_kms_key_arn
+    ]
+  }
+}
+
 data "aws_iam_policy_document" "tfe_ec2_allow_rds_kms_cmk" {
   count = var.rds_kms_key_arn != null ? 1 : 0
 
@@ -339,6 +358,7 @@ data "aws_iam_policy_document" "tfe_ec2_combined" {
     var.tfe_tls_ca_bundle_secret_arn != null ? data.aws_iam_policy_document.tfe_ec2_get_tls_ca_bundle_secret[0].json : "",
     var.tfe_database_password_secret_arn != null ? data.aws_iam_policy_document.tfe_ec2_get_rds_password_secret[0].json : "",
     var.tfe_redis_password_secret_arn != null ? data.aws_iam_policy_document.tfe_ec2_allow_get_redis_password_secret[0].json : "",
+    var.ebs_kms_key_arn != null ? data.aws_iam_policy_document.tfe_ec2_allow_ebs_kms_cmk[0].json : "",
     var.rds_kms_key_arn != null ? data.aws_iam_policy_document.tfe_ec2_allow_rds_kms_cmk[0].json : "",
     var.s3_kms_key_arn != null ? data.aws_iam_policy_document.tfe_ec2_allow_s3_kms_cmk[0].json : "",
     var.redis_kms_key_arn != null ? data.aws_iam_policy_document.tfe_ec2_allow_redis_kms_cmk[0].json : "",


### PR DESCRIPTION
## Description
Add missing IAM policy document for EBS volume encryption when a user passes in a KMS customer managed key (CMK) to encrypt the EBS volume within the Auto Scaling group (via `ebs_kms_key_arn` input).

## Related issue
N/A

## Type of change
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ x] This change requires a documentation update

## How has this been tested?
- Successfully deployed module both with and without a value for `ebs_kms_key_arn`
- Terraform runs executed successfully within workspaces

## Checklist
- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional notes
N/A
