### PR TITLE
Update health check handling for Semver 2.0 compliance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,8 @@
 *.tfstate.*
 
 # Ignore all .tfvars files, which are likely to contain sensitive data, such as
-# password, private keys, and other secrets. These should not be part of version 
-# control as they are data points which are potentially sensitive and subject 
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
 # to change depending on the environment.
 *.tfvars
 *.tfvars.json
@@ -49,3 +49,4 @@ local_*.yaml
 
 # Ignore module-generated Helm overrides file
 module_generated_helm_overrides.yaml
+/tmp

--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -18,11 +18,12 @@ locals {
   is_semver_tag  = can(regex("^[0-9]+\\.[0-9]+(\\.[0-9]+)?$", local.normalized_tag))
 
   major = local.is_semver_tag ? tonumber(split(".", local.normalized_tag)[0]) : 0
+	minor = local.is_semver_tag ? tonumber(split(".", local.normalized_tag)[1]) : 0
 
   tfe_image_tag_gte_1 = (
     !local.is_calver_tag &&
     local.is_semver_tag &&
-    local.major > 1
+    ( local.major >= 1 && local.minor >= 2 )
   )
 }
 

--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -18,7 +18,7 @@ locals {
   is_semver_tag  = can(regex("^[0-9]+\\.[0-9]+(\\.[0-9]+)?$", local.normalized_tag))
 
   major = local.is_semver_tag ? tonumber(split(".", local.normalized_tag)[0]) : 0
-	minor = local.is_semver_tag ? tonumber(split(".", local.normalized_tag)[1]) : 0
+  minor = local.is_semver_tag ? tonumber(split(".", local.normalized_tag)[1]) : 0
 
   tfe_image_tag_gte_1 = (
     !local.is_calver_tag &&

--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -19,11 +19,12 @@ locals {
 
   major = local.is_semver_tag ? tonumber(split(".", local.normalized_tag)[0]) : 0
   minor = local.is_semver_tag ? tonumber(split(".", local.normalized_tag)[1]) : 0
+  patch = local.is_semver_tag ? tonumber(split(".", local.normalized_tag)[2]) : 0
 
   tfe_image_tag_gte_1 = (
     !local.is_calver_tag &&
     local.is_semver_tag &&
-    (local.major > 1 || (local.major == 1 && local.minor >= 2))
+    (local.major > 1 || (local.major == 1 && local.minor >= 2 && local.patch >= 1))
   )
 }
 

--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -7,9 +7,9 @@
 locals {
   lb_name_suffix = var.lb_is_internal ? "internal" : "external"
   # Exclude date-style tags like v202507-1
-  #local.tfe_image_tag_gte_1_3 will be:
-  # true:  2.0 ,2.1
-  # false: 1.2.9, v202507-1, latest, foo
+  # local.tfe_image_tag_gte_1 will be true for non-calver semver-ish tags with major >= 1 and minor >= 2
+  # true:  1.2, 1.3.0, 2.2
+  # false: 1.1.9, v202507-1, latest, foo
 
   is_calver_tag = can(regex("^v[0-9]{6}-[0-9]+$", var.tfe_image_tag))
 

--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -7,8 +7,8 @@
 locals {
   lb_name_suffix = var.lb_is_internal ? "internal" : "external"
   # Exclude date-style tags like v202507-1
-  # local.tfe_image_tag_gte_1 will be true for non-calver semver-ish tags with major >= 1 and minor >= 2
-  # true:  1.2, 1.3.0, 2.2
+  # local.tfe_image_tag_gte_1 will be true for non-calver semver-ish tags with major >= 1 and minor >= 2, or major > 1. This is used to determine the health check path for the load balancer target groups, as TFE 1.2+ uses a different path than earlier versions.
+  # true:  1.2, 1.3.0, 2.0
   # false: 1.1.9, v202507-1, latest, foo
 
   is_calver_tag = can(regex("^v[0-9]{6}-[0-9]+$", var.tfe_image_tag))
@@ -23,7 +23,7 @@ locals {
   tfe_image_tag_gte_1 = (
     !local.is_calver_tag &&
     local.is_semver_tag &&
-    ( local.major >= 1 && local.minor >= 2 )
+    (local.major > 1 || (local.major == 1 && local.minor >= 2))
   )
 }
 

--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -8,7 +8,7 @@ locals {
   lb_name_suffix = var.lb_is_internal ? "internal" : "external"
   # Exclude date-style tags like v202507-1
   #local.tfe_image_tag_gte_1_3 will be:
-  # true: 1.3, 1.3.7, v1.4.0, 2.0
+  # true:  2.0 ,2.1
   # false: 1.2.9, v202507-1, latest, foo
 
   is_calver_tag = can(regex("^v[0-9]{6}-[0-9]+$", var.tfe_image_tag))
@@ -18,15 +18,11 @@ locals {
   is_semver_tag  = can(regex("^[0-9]+\\.[0-9]+(\\.[0-9]+)?$", local.normalized_tag))
 
   major = local.is_semver_tag ? tonumber(split(".", local.normalized_tag)[0]) : 0
-  minor = local.is_semver_tag ? tonumber(split(".", local.normalized_tag)[1]) : 0
 
-  tfe_image_tag_gte_1_3 = (
+  tfe_image_tag_gte_1 = (
     !local.is_calver_tag &&
     local.is_semver_tag &&
-    (
-      local.major > 1 ||
-      (local.major == 1 && local.minor >= 2)
-    )
+    local.major > 1
   )
 }
 
@@ -75,7 +71,7 @@ resource "aws_lb_target_group" "nlb_443" {
 
   health_check {
     protocol            = "HTTPS"
-    path                = local.tfe_image_tag_gte_1_3 ? "/api/v1/health/readiness" : "/_health_check"
+    path                = local.tfe_image_tag_gte_1 ? "/api/v1/health/readiness" : "/_health_check"
     port                = "traffic-port"
     matcher             = "200"
     healthy_threshold   = 5
@@ -143,7 +139,7 @@ resource "aws_lb_target_group" "alb_443" {
 
   health_check {
     protocol            = "HTTPS"
-    path                = local.tfe_image_tag_gte_1_3 ? "/api/v1/health/readiness" : "/_health_check"
+    path                = local.tfe_image_tag_gte_1 ? "/api/v1/health/readiness" : "/_health_check"
     healthy_threshold   = 2
     unhealthy_threshold = 7
     timeout             = 5

--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -6,6 +6,28 @@
 #------------------------------------------------------------------------------
 locals {
   lb_name_suffix = var.lb_is_internal ? "internal" : "external"
+  # Exclude date-style tags like v202507-1
+  #local.tfe_image_tag_gte_1_3 will be:
+  # true: 1.3, 1.3.7, v1.4.0, 2.0
+  # false: 1.2.9, v202507-1, latest, foo
+
+  is_calver_tag = can(regex("^v[0-9]{6}-[0-9]+$", var.tfe_image_tag))
+
+  # Accept semver-ish tags like 1.3, 1.3.2, v1.3, v1.3.2
+  normalized_tag = trimprefix(var.tfe_image_tag, "v")
+  is_semver_tag  = can(regex("^[0-9]+\\.[0-9]+(\\.[0-9]+)?$", local.normalized_tag))
+
+  major = local.is_semver_tag ? tonumber(split(".", local.normalized_tag)[0]) : 0
+  minor = local.is_semver_tag ? tonumber(split(".", local.normalized_tag)[1]) : 0
+
+  tfe_image_tag_gte_1_3 = (
+    !local.is_calver_tag &&
+    local.is_semver_tag &&
+    (
+      local.major > 1 ||
+      (local.major == 1 && local.minor >= 2)
+    )
+  )
 }
 
 #------------------------------------------------------------------------------
@@ -53,7 +75,7 @@ resource "aws_lb_target_group" "nlb_443" {
 
   health_check {
     protocol            = "HTTPS"
-    path                = "/_health_check"
+    path                = local.tfe_image_tag_gte_1_3 ? "/api/v1/health/readiness" : "/_health_check"
     port                = "traffic-port"
     matcher             = "200"
     healthy_threshold   = 5
@@ -121,7 +143,7 @@ resource "aws_lb_target_group" "alb_443" {
 
   health_check {
     protocol            = "HTTPS"
-    path                = "/_health_check"
+    path                = local.tfe_image_tag_gte_1_3 ? "/api/v1/health/readiness" : "/_health_check"
     healthy_threshold   = 2
     unhealthy_threshold = 7
     timeout             = 5

--- a/templates/tfe_user_data.sh.tpl
+++ b/templates/tfe_user_data.sh.tpl
@@ -717,13 +717,18 @@ function main {
   sleep 60
 
   log "INFO" "Polling TFE health check endpoint until the app becomes ready..."
-  if [[ "$tfe_image_tag" == v* ]]	; then
-		log "INFO" "Detected TFE image tag '$tfe_image_tag' follows calver versioning. Using '/_health_check' endpoint for health checks."
-  while ! curl -ksfS --connect-timeout 5 https://$VM_PRIVATE_IP/_health_check; do
-    sleep 5
-  done
+  if [[ "${tfe_image_tag}" == v* ]]	; then
+	  log "INFO" "Detected TFE image tag '$tfe_image_tag' follows calver versioning. Using '/_health_check' endpoint for health checks."
+    while ! curl -ksfS --connect-timeout 5 https://$VM_PRIVATE_IP/_health_check; do
+      sleep 5
+    done
+	elif [[ "${tfe_image_tag}" == 1.* ]]; then
+	  log "INFO" "Detected TFE image tag '$tfe_image_tag' appears to follow semantic versioning but less than 2.0. Using '/_health_check' endpoint for health checks."
+    while ! curl -ksfS --connect-timeout 5 https://$VM_PRIVATE_IP/_health_check; do
+      sleep 5
+    done
 	else
-		log "INFO" "Using '/api/v1/health/readiness' endpoint for health checks. '$tfe_image_tag' does not appears to follow semantic versioning."
+	  log "INFO" "Using '/api/v1/health/readiness' endpoint for health checks. '$tfe_image_tag' does not appears to follow semantic versioning."
 	while ! curl -ksfS --connect-timeout 5 https://$VM_PRIVATE_IP/api/v1/health/readiness; do
 		sleep 5
 	done

--- a/templates/tfe_user_data.sh.tpl
+++ b/templates/tfe_user_data.sh.tpl
@@ -717,18 +717,18 @@ function main {
   sleep 60
 
   log "INFO" "Polling TFE health check endpoint until the app becomes ready..."
-  if [[ "${tfe_image_tag}" == v* ]]	; then
-	  log "INFO" "Detected TFE image tag '$tfe_image_tag' follows calver versioning. Using '/_health_check' endpoint for health checks."
+  if [[ "${tfe_image_tag}" == v[0-9][0-9][0-9][0-9][0-9][0-9]-* ]]; then
+	  log "INFO" "Detected TFE image tag '$tfe_image_tag' follows calver versioning (vYYYYMM-N). Using '/_health_check' endpoint for health checks."
     while ! curl -ksfS --connect-timeout 5 https://$VM_PRIVATE_IP/_health_check; do
       sleep 5
     done
-	elif [[ "${tfe_image_tag}" == 1.* ]]; then
+	elif [[ "${tfe_image_tag}" == 1.* || "${tfe_image_tag}" == v1.* ]]; then
 	  log "INFO" "Detected TFE image tag '$tfe_image_tag' appears to follow semantic versioning but less than 2.0. Using '/_health_check' endpoint for health checks."
     while ! curl -ksfS --connect-timeout 5 https://$VM_PRIVATE_IP/_health_check; do
       sleep 5
     done
 	else
-	  log "INFO" "Using '/api/v1/health/readiness' endpoint for health checks. '$tfe_image_tag' does not appears to follow semantic versioning."
+	  log "INFO" "Using '/api/v1/health/readiness' endpoint for health checks. '$tfe_image_tag' does not appears to follow semantic versioning less than 2.0 or calver."
 	while ! curl -ksfS --connect-timeout 5 https://$VM_PRIVATE_IP/api/v1/health/readiness; do
 		sleep 5
 	done

--- a/templates/tfe_user_data.sh.tpl
+++ b/templates/tfe_user_data.sh.tpl
@@ -21,7 +21,7 @@ function detect_os_distro {
   local OS_DISTRO_NAME=$(grep "^NAME=" /etc/os-release | cut -d"\"" -f2)
   local OS_DISTRO_DETECTED
 
-  case "$OS_DISTRO_NAME" in 
+  case "$OS_DISTRO_NAME" in
     "Ubuntu"*)
       OS_DISTRO_DETECTED="ubuntu"
       ;;
@@ -45,8 +45,8 @@ function detect_os_distro {
 function install_awscli {
   local OS_DISTRO="$1"
   local OS_VERSION=$(grep "^VERSION=" /etc/os-release | cut -d"\"" -f2)
-  
-  if command -v aws > /dev/null; then 
+
+  if command -v aws > /dev/null; then
     log "INFO" "Detected 'aws-cli' is already installed. Skipping."
   else
     log "INFO" "Installing 'aws-cli'."
@@ -76,7 +76,7 @@ function install_awscli {
 function install_docker {
   local OS_DISTRO="$1"
   local OS_MAJOR_VERSION=$(grep "^VERSION_ID=" /etc/os-release | cut -d"\"" -f2 | cut -d"." -f1)
-  
+
   if command -v docker > /dev/null; then
     log "INFO" "Detected 'docker' is already installed. Skipping."
   else
@@ -106,7 +106,7 @@ function install_docker {
     fi
     systemctl enable --now docker.service
   fi
-  
+
   if [[ "${http_proxy}" != "" || "${https_proxy}" != "" ]]; then
     log "INFO" "Configuring proxy settings for Docker daemon."
     mkdir -p /etc/systemd/system/docker.service.d
@@ -151,7 +151,7 @@ function install_podman {
 function retrieve_license_from_awssm {
   local SECRET_ARN="$1"
   local SECRET_REGION=$AWS_REGION
-  
+
   if [[ -z "$SECRET_ARN" ]]; then
     log "ERROR" "Secret ARN cannot be empty. Exiting."
     exit_script 4
@@ -194,7 +194,7 @@ EOF
 
 function generate_tfe_docker_compose_file {
   local TFE_SETTINGS_PATH="$1"
-  
+
   cat > "$TFE_SETTINGS_PATH" << EOF
 ---
 name: tfe
@@ -239,11 +239,11 @@ services:
 %{ endif ~}
       TFE_OBJECT_STORAGE_S3_SERVER_SIDE_ENCRYPTION: ${tfe_object_storage_s3_server_side_encryption}
       TFE_OBJECT_STORAGE_S3_SERVER_SIDE_ENCRYPTION_KMS_KEY_ID: ${tfe_object_storage_s3_server_side_encryption_kms_key_id}
-      
+
 %{ if tfe_operational_mode == "active-active" ~}
       # Vault settings
       TFE_VAULT_CLUSTER_ADDRESS: https://$VM_PRIVATE_IP:8201
-      
+
       # Redis settings.
       TFE_REDIS_HOST: ${tfe_redis_host}
       TFE_REDIS_USE_TLS: ${tfe_redis_use_tls}
@@ -280,7 +280,7 @@ services:
       TFE_IACT_SUBNETS: ${tfe_iact_subnets}
       TFE_IACT_TRUSTED_PROXIES: ${tfe_iact_trusted_proxies}
       TFE_IACT_TIME_LIMIT: ${tfe_iact_time_limit}
-      
+
       # Network settings
 %{ if http_proxy != "" || https_proxy != ""  ~}
       http_proxy: ${http_proxy}
@@ -336,7 +336,7 @@ EOF
 
 function generate_tfe_podman_manifest {
   local TFE_SETTINGS_PATH="$1"
-  
+
   cat > $TFE_SETTINGS_PATH << EOF
 ---
 apiVersion: "v1"
@@ -474,7 +474,7 @@ spec:
       value: /var/cache/tfe-task-worker
     - name: "TFE_DISK_CACHE_VOLUME_NAME"
       value: terraform-enterprise-cache
-    
+
     # Initial admin creation token settings
     - name: "TFE_IACT_TOKEN"
       value: ${tfe_iact_token}
@@ -484,7 +484,7 @@ spec:
       value: ${tfe_iact_trusted_proxies}
     - name: "TFE_IACT_TIME_LIMIT"
       value: ${tfe_iact_time_limit}
-    
+
     # Network settings
 %{ if http_proxy != "" || https_proxy != ""  ~}
     - name:  "http_proxy"
@@ -597,7 +597,7 @@ function pull_tfe_app_image {
   log "INFO" "Detected TFE container image registry URL is '${tfe_image_repository_url}'."
   log "INFO" "Detected TFE container image name is '${tfe_image_name}'."
   log "INFO" "Detected TFE container image repository username is '${tfe_image_repository_username}'."
-  
+
   # Authenticate to container registry
   if [[ "${tfe_image_repository_url}" == "images.releases.hashicorp.com" ]]; then
     log "INFO" "Detected default TFE container registry was specified. Using TFE license to authenticate to TFE container registry."
@@ -618,19 +618,19 @@ function pull_tfe_app_image {
     echo "Attempting to authenticate to '${tfe_image_repository_url}' container registry."
     $TFE_CONTAINER_RUNTIME login ${tfe_image_repository_url} --username ${tfe_image_repository_username} --password ${tfe_image_repository_password}
   fi
-  
+
   # Download TFE application container image
   log "INFO" "Pulling TFE application container image '${tfe_image_repository_url}/${tfe_image_name}:${tfe_image_tag}' down locally."
   $TFE_CONTAINER_RUNTIME pull ${tfe_image_repository_url}/${tfe_image_name}:${tfe_image_tag}
 }
 
-function exit_script { 
+function exit_script {
   if [[ "$1" == 0 ]]; then
     log "INFO" "tfe_user_data script finished successfully!"
   else
     log "ERROR" "tfe_user_data script finished with error code $1."
   fi
-  
+
   exit "$1"
 }
 
@@ -641,7 +641,7 @@ function main {
   log "INFO" "Detected Linux OS distro is '$OS_DISTRO'."
   OS_MAJOR_VERSION=$(grep "^VERSION_ID=" /etc/os-release | cut -d"\"" -f2 | cut -d"." -f1)
   log "INFO" "Detected OS major version is '$OS_MAJOR_VERSION'."
-  
+
   log "INFO" "Scraping EC2 instance metadata for private IP address..."
   EC2_TOKEN=$(curl --noproxy -sS -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
   VM_PRIVATE_IP=$(curl --noproxy -sS -H "X-aws-ec2-metadata-token: $EC2_TOKEN" http://169.254.169.254/latest/meta-data/local-ipv4)
@@ -656,8 +656,8 @@ function main {
     export https_proxy="${https_proxy}"
     NO_PROXY="${no_proxy},$VM_PRIVATE_IP"
     export no_proxy=$NO_PROXY
-    echo 'http_proxy="${http_proxy}"' | tee -a /etc/environment > /dev/null 
-    echo 'https_proxy="${https_proxy}"' | tee -a /etc/environment > /dev/null 
+    echo 'http_proxy="${http_proxy}"' | tee -a /etc/environment > /dev/null
+    echo 'https_proxy="${https_proxy}"' | tee -a /etc/environment > /dev/null
     echo "no_proxy=\"$NO_PROXY\"" | tee -a /etc/environment > /dev/null
   fi
 
@@ -686,7 +686,7 @@ function main {
     log "INFO" "Generating '$TFE_LOG_FORWARDING_CONFIG_PATH' file for log forwarding."
     configure_log_forwarding
   fi
-  
+
   log "INFO" "Preparing to download TFE application container image..."
   pull_tfe_app_image "${container_runtime}" "${tfe_image_repository_password}"
 
@@ -717,9 +717,17 @@ function main {
   sleep 60
 
   log "INFO" "Polling TFE health check endpoint until the app becomes ready..."
+  if [[ "$tfe_image_tag" == v* ]]	; then
+		log "INFO" "Detected TFE image tag '$tfe_image_tag' follows calver versioning. Using '/_health_check' endpoint for health checks."
   while ! curl -ksfS --connect-timeout 5 https://$VM_PRIVATE_IP/_health_check; do
     sleep 5
   done
+	else
+		log "INFO" "Using '/api/v1/health/readiness' endpoint for health checks. '$tfe_image_tag' does not appears to follow semantic versioning."
+	while ! curl -ksfS --connect-timeout 5 https://$VM_PRIVATE_IP/api/v1/health/readiness; do
+		sleep 5
+	done
+	fi
 
   exit_script 0
 }

--- a/templates/tfe_user_data.sh.tpl
+++ b/templates/tfe_user_data.sh.tpl
@@ -728,7 +728,7 @@ function main {
 	  HEALTH_CHECK_PATH="/api/v1/health/readiness"
 	fi
 
-  while ! curl -ksfS --connect-timeout 5 "https://$VM_PRIVATE_IP${HEALTH_CHECK_PATH}"; do
+  while ! curl -ksfS --connect-timeout 5 "https://$VM_PRIVATE_IP$HEALTH_CHECK_PATH"; do
     sleep 5
   done
   exit_script 0

--- a/templates/tfe_user_data.sh.tpl
+++ b/templates/tfe_user_data.sh.tpl
@@ -719,21 +719,18 @@ function main {
   log "INFO" "Polling TFE health check endpoint until the app becomes ready..."
   if [[ "${tfe_image_tag}" == v[0-9][0-9][0-9][0-9][0-9][0-9]-* ]]; then
 	  log "INFO" "Detected TFE image tag '$tfe_image_tag' follows calver versioning (vYYYYMM-N). Using '/_health_check' endpoint for health checks."
-    while ! curl -ksfS --connect-timeout 5 https://$VM_PRIVATE_IP/_health_check; do
-      sleep 5
-    done
-	elif [[ "${tfe_image_tag}" == 1.* || "${tfe_image_tag}" == v1.* ]]; then
+    HEALTH_CHECK_PATH="/_health_check"
+	elif [[ "${tfe_image_tag}" == 1.* ]]; then
 	  log "INFO" "Detected TFE image tag '$tfe_image_tag' appears to follow semantic versioning but less than 2.0. Using '/_health_check' endpoint for health checks."
-    while ! curl -ksfS --connect-timeout 5 https://$VM_PRIVATE_IP/_health_check; do
-      sleep 5
-    done
+    HEALTH_CHECK_PATH="/_health_check"
 	else
-	  log "INFO" "Using '/api/v1/health/readiness' endpoint for health checks. '$tfe_image_tag' does not appears to follow semantic versioning less than 2.0 or calver."
-	while ! curl -ksfS --connect-timeout 5 https://$VM_PRIVATE_IP/api/v1/health/readiness; do
-		sleep 5
-	done
+	  log "INFO" "Using '/api/v1/health/readiness' endpoint for health checks. '$tfe_image_tag' does not appears to follow semantic versioning."
+	  HEALTH_CHECK_PATH="/api/v1/health/readiness"
 	fi
 
+  while ! curl -ksfS --connect-timeout 5 "https://$VM_PRIVATE_IP${HEALTH_CHECK_PATH}"; do
+    sleep 5
+  done
   exit_script 0
 }
 

--- a/templates/tfe_user_data.sh.tpl
+++ b/templates/tfe_user_data.sh.tpl
@@ -724,7 +724,7 @@ function main {
 	  log "INFO" "Detected TFE image tag '$tfe_image_tag' appears to follow semantic versioning but less than 2.0. Using '/_health_check' endpoint for health checks."
     HEALTH_CHECK_PATH="/_health_check"
 	else
-	  log "INFO" "Using '/api/v1/health/readiness' endpoint for health checks. '$tfe_image_tag' does not appears to follow semantic versioning."
+	  log "INFO" "Using '/api/v1/health/readiness' endpoint for health checks. '$tfe_image_tag' does not appear to follow semantic versioning."
 	  HEALTH_CHECK_PATH="/api/v1/health/readiness"
 	fi
 


### PR DESCRIPTION
## Description

This pull request updates health check logic for load balancers and the user data script to better support different TFE image tag formats. The main improvement is to dynamically select the appropriate health check endpoint based on whether the TFE image tag uses calendar versioning (calver) or semantic versioning (semver). This ensures compatibility with both legacy and newer TFE images.

**Health check endpoint selection improvements:**

* Added logic in `load_balancer.tf` to detect if `var.tfe_image_tag` is a calver or semver tag, and set the `tfe_image_tag_gte_1` local variable accordingly.
* Updated the health check `path` for both `aws_lb_target_group.nlb_443` and `aws_lb_target_group.alb_443` to use `/api/v1/health/readiness` for semver tags greater than 1, and `/ _health_check` for calver or older tags. [[1]](diffhunk://#diff-a6e7625f9b7d2f21ce6485972fe6b77c08811af9016d011b855a9c66684b59e2L56-R74) [[2]](diffhunk://#diff-a6e7625f9b7d2f21ce6485972fe6b77c08811af9016d011b855a9c66684b59e2L124-R142)
* handles bug in 1.2.0 which is not compatible with NLB, so honours change as of 1.2.1

**User data script enhancements:**

* Modified `templates/tfe_user_data.sh.tpl` to poll the correct health check endpoint depending on the format of `$tfe_image_tag`, with improved logging for clarity. 

## Related issue
NA

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How has this been tested?
- deploy and test 

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional notes

