### PR TITLE
add tfe admin capability and resources.

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 
 | Name | Type |
 |------|------|
+| [aws_autoscaling_attachment.tfe_asg_attachment_alb_admin_console](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_attachment) | resource |
+| [aws_autoscaling_attachment.tfe_asg_attachment_nlb_admin_console](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_attachment) | resource |
 | [aws_autoscaling_group.tfe](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
 | [aws_db_parameter_group.tfe](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_parameter_group) | resource |
 | [aws_db_subnet_group.tfe](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_subnet_group) | resource |
@@ -223,9 +225,13 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | [aws_lb.alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
 | [aws_lb.nlb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
 | [aws_lb_listener.alb_443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_listener.alb_admin_console](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
 | [aws_lb_listener.lb_nlb_443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_listener.lb_nlb_admin_console](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
 | [aws_lb_target_group.alb_443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_lb_target_group.alb_admin_console](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
 | [aws_lb_target_group.nlb_443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_lb_target_group.nlb_admin_console](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
 | [aws_rds_cluster.tfe](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster) | resource |
 | [aws_rds_cluster_instance.tfe](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_instance) | resource |
 | [aws_rds_cluster_parameter_group.tfe](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_parameter_group) | resource |
@@ -249,15 +255,21 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | [aws_security_group_rule.ec2_allow_egress_dns_udp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ec2_allow_egress_http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ec2_allow_egress_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ec2_allow_egress_proxy_admin_console](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ec2_allow_egress_proxy_http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ec2_allow_egress_proxy_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ec2_allow_egress_rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ec2_allow_egress_redis](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ec2_allow_egress_tfe_admin_console](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ec2_allow_egress_vault](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ec2_allow_ingress_ssh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ec2_allow_ingress_tfe_admin_console](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ec2_allow_ingress_tfe_admin_console_ipv6](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ec2_allow_ingress_tfe_https_from_lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ec2_allow_ingress_vault](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.lb_allow_egress_all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.lb_allow_ingress_admin_console_from_cidr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.lb_allow_ingress_admin_console_from_ec2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.lb_allow_ingress_tfe_https_from_cidr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.lb_allow_ingress_tfe_https_from_ec2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.rds_allow_ingress_from_ec2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
@@ -323,6 +335,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | <a name="input_cidr_allow_egress_ec2_proxy"></a> [cidr\_allow\_egress\_ec2\_proxy](#input\_cidr\_allow\_egress\_ec2\_proxy) | List of destination CIDR range(s) where proxy server exists. Required and only valid when `http_proxy` and/or `https_proxy` are set. | `list(string)` | `null` | no |
 | <a name="input_cidr_allow_ingress_ec2_ssh"></a> [cidr\_allow\_ingress\_ec2\_ssh](#input\_cidr\_allow\_ingress\_ec2\_ssh) | List of CIDR ranges to allow SSH ingress to TFE EC2 instance (i.e. bastion IP, client/workstation IP, etc.). | `list(string)` | `null` | no |
 | <a name="input_cidr_allow_ingress_tfe_443"></a> [cidr\_allow\_ingress\_tfe\_443](#input\_cidr\_allow\_ingress\_tfe\_443) | List of CIDR ranges allowed to access the TFE application over HTTPS (port 443). | `list(string)` | <pre>[<br/>  "0.0.0.0/0"<br/>]</pre> | no |
+| <a name="input_cidr_allow_ingress_tfe_admin_console"></a> [cidr\_allow\_ingress\_tfe\_admin\_console](#input\_cidr\_allow\_ingress\_tfe\_admin\_console) | List of CIDR ranges to allow ingress traffic on the admin console port. Required when `tfe_admin_console_disabled` is `false`. | `list(string)` | `null` | no |
 | <a name="input_cidr_allow_ingress_tfe_metrics_http"></a> [cidr\_allow\_ingress\_tfe\_metrics\_http](#input\_cidr\_allow\_ingress\_tfe\_metrics\_http) | List of CIDR ranges to allow TCP/9090 (HTTP) inbound to metrics endpoint on TFE EC2 instances. | `list(string)` | `null` | no |
 | <a name="input_cidr_allow_ingress_tfe_metrics_https"></a> [cidr\_allow\_ingress\_tfe\_metrics\_https](#input\_cidr\_allow\_ingress\_tfe\_metrics\_https) | List of CIDR ranges to allow TCP/9091 (HTTPS) inbound to metrics endpoint on TFE EC2 instances. | `list(string)` | `null` | no |
 | <a name="input_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#input\_cloudwatch\_log\_group\_name) | Name of CloudWatch Log Group to configure as log forwarding destination. Only valid when `tfe_log_forwarding_enabled` is `true`. | `string` | `null` | no |
@@ -393,6 +406,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | <a name="input_s3_force_destroy"></a> [s3\_force\_destroy](#input\_s3\_force\_destroy) | Boolean to enable force destruction of S3 bucket and all objects within it. When `true`, the bucket can be destroyed even if it contains objects. | `bool` | `false` | no |
 | <a name="input_s3_kms_key_arn"></a> [s3\_kms\_key\_arn](#input\_s3\_kms\_key\_arn) | ARN of KMS customer managed key (CMK) to encrypt TFE S3 bucket with. | `string` | `null` | no |
 | <a name="input_s3_log_fwd_bucket_name"></a> [s3\_log\_fwd\_bucket\_name](#input\_s3\_log\_fwd\_bucket\_name) | Name of S3 bucket to configure as log forwarding destination. Only valid when `tfe_log_forwarding_enabled` is `true`. | `string` | `null` | no |
+| <a name="input_tfe_admin_console_disabled"></a> [tfe\_admin\_console\_disabled](#input\_tfe\_admin\_console\_disabled) | Boolean to disable the TFE Admin Console for advanced troubleshooting and diagnostics. When disabled, the admin console will not be accessible. | `bool` | `true` | no |
 | <a name="input_tfe_admin_https_port"></a> [tfe\_admin\_https\_port](#input\_tfe\_admin\_https\_port) | Port the TFE application container listens on for [system (admin) API endpoints](https://developer.hashicorp.com/terraform/enterprise/api-docs#system-endpoints-overview) HTTPS traffic. This value is used for both the host and container port. | `number` | `9443` | no |
 | <a name="input_tfe_alb_tls_certificate_arn"></a> [tfe\_alb\_tls\_certificate\_arn](#input\_tfe\_alb\_tls\_certificate\_arn) | ARN of existing TFE TLS certificate imported in ACM to be used for application load balancer (ALB) HTTPS listeners. Required when `lb_type` is `alb`. | `string` | `null` | no |
 | <a name="input_tfe_capacity_concurrency"></a> [tfe\_capacity\_concurrency](#input\_tfe\_capacity\_concurrency) | Maximum number of concurrent Terraform runs to allow on a TFE node. | `number` | `10` | no |
@@ -446,6 +460,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | <a name="output_s3_bucket_arn"></a> [s3\_bucket\_arn](#output\_s3\_bucket\_arn) | ARN of TFE S3 bucket. |
 | <a name="output_s3_bucket_name"></a> [s3\_bucket\_name](#output\_s3\_bucket\_name) | Name of TFE S3 bucket. |
 | <a name="output_s3_crr_iam_role_arn"></a> [s3\_crr\_iam\_role\_arn](#output\_s3\_crr\_iam\_role\_arn) | ARN of S3 cross-region replication IAM role. |
+| <a name="output_tfe_admin_console_url_pattern"></a> [tfe\_admin\_console\_url\_pattern](#output\_tfe\_admin\_console\_url\_pattern) | URL pattern to access the TFE Admin Console. Only applicable if `tfe_admin_console_disabled` is set to false. |
 | <a name="output_tfe_create_initial_admin_user_url"></a> [tfe\_create\_initial\_admin\_user\_url](#output\_tfe\_create\_initial\_admin\_user\_url) | URL to create TFE initial admin user. |
 | <a name="output_tfe_database_host"></a> [tfe\_database\_host](#output\_tfe\_database\_host) | PostgreSQL server endpoint in the format that TFE will connect to. |
 | <a name="output_tfe_url"></a> [tfe\_url](#output\_tfe\_url) | URL to access TFE application based on value of `tfe_fqdn` input. |

--- a/compute.tf
+++ b/compute.tf
@@ -142,6 +142,8 @@ locals {
     no_proxy             = var.additional_no_proxy != null ? "${var.additional_no_proxy},${local.addl_no_proxy_base}" : local.addl_no_proxy_base
     tfe_ipv6_enabled     = var.tfe_ipv6_enabled
     tfe_admin_https_port = var.tfe_admin_https_port
+    # Admin Console settings
+    tfe_admin_console_disabled = var.tfe_admin_console_disabled
   }
 
   tfe_startup_script_tpl      = var.custom_tfe_startup_script_template != null ? "${path.cwd}/templates/${var.custom_tfe_startup_script_template}" : "${path.module}/templates/tfe_user_data.sh.tpl"
@@ -462,6 +464,62 @@ resource "aws_security_group_rule" "ec2_allow_egress_proxy_https" {
   protocol    = "tcp"
   cidr_blocks = var.cidr_allow_egress_ec2_proxy
   description = "Allow TCP/${local.https_proxy_port} (HTTPS proxy port) outbound to specified CIDR ranges from TFE EC2 instances."
+
+  security_group_id = aws_security_group.ec2_allow_egress.id
+}
+
+#------------------------------------------------------------------------------
+# Admin console ingress rules
+#------------------------------------------------------------------------------
+
+resource "aws_security_group_rule" "ec2_allow_ingress_tfe_admin_console" {
+  count = !var.tfe_admin_console_disabled ? 1 : 0
+
+  type        = "ingress"
+  from_port   = var.tfe_admin_https_port
+  to_port     = var.tfe_admin_https_port
+  protocol    = "tcp"
+  cidr_blocks = var.cidr_allow_ingress_tfe_admin_console
+  description = "Allow TCP/${var.tfe_admin_https_port} (Admin Console HTTPS) inbound to TFE EC2 instances from specified CIDR ranges."
+
+  security_group_id = aws_security_group.ec2_allow_ingress.id
+}
+
+
+
+resource "aws_security_group_rule" "ec2_allow_ingress_tfe_admin_console_ipv6" {
+  count = !var.tfe_admin_console_disabled && var.cidr_allow_ingress_tfe_admin_console != null && length([for cidr in var.cidr_allow_ingress_tfe_admin_console : cidr if can(regex(":", cidr))]) > 0 ? 1 : 0
+
+  type             = "ingress"
+  from_port        = var.tfe_admin_https_port
+  to_port          = var.tfe_admin_https_port
+  protocol         = "tcp"
+  ipv6_cidr_blocks = [for cidr in var.cidr_allow_ingress_tfe_admin_console : cidr if can(regex(":", cidr))]
+  description      = "Allow TCP/${var.tfe_admin_https_port} (Admin Console HTTPS) inbound to TFE EC2 instances from specified IPv6 CIDR ranges."
+
+  security_group_id = aws_security_group.ec2_allow_ingress.id
+}
+
+resource "aws_security_group_rule" "ec2_allow_egress_proxy_admin_console" {
+  count = var.cidr_allow_egress_ec2_proxy != null && local.https_proxy_port != null ? 1 : 0
+
+  type        = "egress"
+  from_port   = var.tfe_admin_https_port
+  to_port     = var.tfe_admin_https_port
+  protocol    = "tcp"
+  cidr_blocks = var.cidr_allow_egress_ec2_proxy
+  description = "Allow TCP/${var.tfe_admin_https_port} (Admin Console HTTPS) outbound to specified CIDR ranges from TFE EC2 instances."
+
+  security_group_id = aws_security_group.ec2_allow_egress.id
+}
+resource "aws_security_group_rule" "ec2_allow_egress_tfe_admin_console" {
+  count       = !var.tfe_admin_console_disabled ? 1 : 0
+  type        = "egress"
+  from_port   = var.tfe_admin_https_port
+  to_port     = var.tfe_admin_https_port
+  protocol    = "tcp"
+  cidr_blocks = var.cidr_allow_egress_ec2_http
+  description = "Allow TCP/443 (HTTPS) outbound to specified CIDR ranges from TFE EC2 instances."
 
   security_group_id = aws_security_group.ec2_allow_egress.id
 }

--- a/compute.tf
+++ b/compute.tf
@@ -504,11 +504,11 @@ resource "aws_security_group_rule" "ec2_allow_egress_proxy_admin_console" {
   count = var.cidr_allow_egress_ec2_proxy != null && local.https_proxy_port != null ? 1 : 0
 
   type        = "egress"
-  from_port   = var.tfe_admin_https_port
-  to_port     = var.tfe_admin_https_port
+  from_port   = local.https_proxy_port
+  to_port     = local.https_proxy_port
   protocol    = "tcp"
   cidr_blocks = var.cidr_allow_egress_ec2_proxy
-  description = "Allow TCP/${var.tfe_admin_https_port} (Admin Console HTTPS) outbound to specified CIDR ranges from TFE EC2 instances."
+  description = "Allow TCP/${local.https_proxy_port} (HTTPS proxy) outbound to specified CIDR ranges from TFE EC2 instances."
 
   security_group_id = aws_security_group.ec2_allow_egress.id
 }

--- a/compute.tf
+++ b/compute.tf
@@ -512,14 +512,3 @@ resource "aws_security_group_rule" "ec2_allow_egress_proxy_admin_console" {
 
   security_group_id = aws_security_group.ec2_allow_egress.id
 }
-resource "aws_security_group_rule" "ec2_allow_egress_tfe_admin_console" {
-  count       = !var.tfe_admin_console_disabled ? 1 : 0
-  type        = "egress"
-  from_port   = var.tfe_admin_https_port
-  to_port     = var.tfe_admin_https_port
-  protocol    = "tcp"
-  cidr_blocks = var.cidr_allow_egress_ec2_http
-  description = "Allow TCP (HTTPS) outbound to specified CIDR ranges from TFE EC2 instances."
-
-  security_group_id = aws_security_group.ec2_allow_egress.id
-}

--- a/compute.tf
+++ b/compute.tf
@@ -473,14 +473,14 @@ resource "aws_security_group_rule" "ec2_allow_egress_proxy_https" {
 #------------------------------------------------------------------------------
 
 resource "aws_security_group_rule" "ec2_allow_ingress_tfe_admin_console" {
-  count = !var.tfe_admin_console_disabled ? 1 : 0
+  count = !var.tfe_admin_console_disabled && var.cidr_allow_ingress_tfe_admin_console != null && length([for cidr in var.cidr_allow_ingress_tfe_admin_console : cidr if !can(regex(":", cidr))]) > 0 ? 1 : 0
 
   type        = "ingress"
   from_port   = var.tfe_admin_https_port
   to_port     = var.tfe_admin_https_port
   protocol    = "tcp"
-  cidr_blocks = var.cidr_allow_ingress_tfe_admin_console
-  description = "Allow TCP/${var.tfe_admin_https_port} (Admin Console HTTPS) inbound to TFE EC2 instances from specified CIDR ranges."
+  cidr_blocks = [for cidr in var.cidr_allow_ingress_tfe_admin_console : cidr if !can(regex(":", cidr))]
+  description = "Allow TCP/${var.tfe_admin_https_port} (Admin Console HTTPS) inbound to TFE EC2 instances from specified IPv4 CIDR ranges."
 
   security_group_id = aws_security_group.ec2_allow_ingress.id
 }
@@ -504,11 +504,11 @@ resource "aws_security_group_rule" "ec2_allow_egress_proxy_admin_console" {
   count = var.cidr_allow_egress_ec2_proxy != null && local.https_proxy_port != null ? 1 : 0
 
   type        = "egress"
-  from_port   = local.https_proxy_port
-  to_port     = local.https_proxy_port
+  from_port   = var.tfe_admin_https_port
+  to_port     = var.tfe_admin_https_port
   protocol    = "tcp"
   cidr_blocks = var.cidr_allow_egress_ec2_proxy
-  description = "Allow TCP/${local.https_proxy_port} (HTTPS proxy) outbound to specified CIDR ranges from TFE EC2 instances."
+  description = "Allow TCP/${var.tfe_admin_https_port} (HTTPS proxy) outbound to specified CIDR ranges from TFE EC2 instances."
 
   security_group_id = aws_security_group.ec2_allow_egress.id
 }
@@ -519,7 +519,7 @@ resource "aws_security_group_rule" "ec2_allow_egress_tfe_admin_console" {
   to_port     = var.tfe_admin_https_port
   protocol    = "tcp"
   cidr_blocks = var.cidr_allow_egress_ec2_http
-  description = "Allow TCP/443 (HTTPS) outbound to specified CIDR ranges from TFE EC2 instances."
+  description = "Allow TCP (HTTPS) outbound to specified CIDR ranges from TFE EC2 instances."
 
   security_group_id = aws_security_group.ec2_allow_egress.id
 }

--- a/examples/main/main.tf
+++ b/examples/main/main.tf
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 terraform {
+  required_version = ">= 1.9"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/examples/main/terraform.tfvars.example
+++ b/examples/main/terraform.tfvars.example
@@ -24,6 +24,10 @@ tfe_metrics_enable     = <false>
 tfe_metrics_http_port  = 9090
 tfe_metrics_https_port = 9091
 
+tfe_admin_https_port = 9443
+tfe_admin_console_disabled = true
+cidr_allow_ingress_tfe_admin_console = ["<10.0.0.0/16>", "1.2.3.4/32"]
+
 # --- Networking --- #
 vpc_id                               = "<my-vpc-id>"
 lb_is_internal                       = true
@@ -69,7 +73,7 @@ redis_multi_az_enabled           = true # requires more than one subnet specifie
 redis_automatic_failover_enabled = true # requires more than one subnet specified in `redis_subnet_ids` when `true`
 
 # --- Log forwarding (optional) --- #
-tfe_log_forwarding_enabled = <true>                      # set to `false` if you have your own 
+tfe_log_forwarding_enabled = <true>                      # set to `false` if you have your own
 log_fwd_destination_type   = "<s3>"                      # either `s3` or `cloudwatch`
 s3_log_fwd_bucket_name     = "<tfe-logging-bucket-name>" # set to `null` or remove when `log_fwd_destination_type` is `cloudwatch`
 #cloudwatch_log_group_name = "<tfe-log-group-name>"      # set to `null` or remove when `log_fwd_destination_type` is `s3`

--- a/examples/main/terraform.tfvars.example
+++ b/examples/main/terraform.tfvars.example
@@ -26,7 +26,7 @@ tfe_metrics_https_port = 9091
 
 tfe_admin_https_port = 9443
 tfe_admin_console_disabled = true
-cidr_allow_ingress_tfe_admin_console = ["<10.0.0.0/16>", "1.2.3.4/32"]
+# cidr_allow_ingress_tfe_admin_console = ["<10.0.0.0/16>", "1.2.3.4/32>"] # Only set when `tfe_admin_console_disabled = false`
 
 # --- Networking --- #
 vpc_id                               = "<my-vpc-id>"

--- a/examples/main/variables.tf
+++ b/examples/main/variables.tf
@@ -273,7 +273,31 @@ variable "tfe_admin_https_port" {
     error_message = "`tfe_admin_https_port` must not be the same as `tfe_https_port` or `tfe_http_port` to avoid conflicts."
   }
 }
+#------------------------------------------------------------------------------
+# Admin Console
+#------------------------------------------------------------------------------
+variable "tfe_admin_console_disabled" {
+  type        = bool
+  description = "Boolean to disable the TFE Admin Console for advanced troubleshooting and diagnostics. When disabled, the admin console will not be accessible."
+  default     = true
+}
 
+variable "cidr_allow_ingress_tfe_admin_console" {
+  type        = list(string)
+  description = "List of CIDR ranges to allow ingress traffic on the admin console port. Required when `tfe_admin_console_disabled` is `false`."
+  default     = null
+
+  validation {
+    condition     = !var.tfe_admin_console_disabled ? var.cidr_allow_ingress_tfe_admin_console != null : true
+    error_message = "Value must be set when `tfe_admin_console_disabled` is `false`. Admin console requires explicit CIDR ranges for security."
+  }
+  validation {
+    condition = var.cidr_allow_ingress_tfe_admin_console != null ? alltrue([
+      for cidr in var.cidr_allow_ingress_tfe_admin_console : can(cidrhost(cidr, 0))
+    ]) : true
+    error_message = "All values must be valid CIDR notation (e.g., '10.0.0.0/8')."
+  }
+}
 #------------------------------------------------------------------------------
 # Networking
 #------------------------------------------------------------------------------

--- a/examples/main/variables.tf
+++ b/examples/main/variables.tf
@@ -288,8 +288,8 @@ variable "cidr_allow_ingress_tfe_admin_console" {
   default     = null
 
   validation {
-    condition     = !var.tfe_admin_console_disabled ? var.cidr_allow_ingress_tfe_admin_console != null : true
-    error_message = "Value must be set when `tfe_admin_console_disabled` is `false`. Admin console requires explicit CIDR ranges for security."
+    condition     = !var.tfe_admin_console_disabled ? (var.cidr_allow_ingress_tfe_admin_console != null && length(var.cidr_allow_ingress_tfe_admin_console) > 0) : true
+    error_message = "Value must be set to a non-empty list when `tfe_admin_console_disabled` is `false`. Admin console requires at least one explicit CIDR range for security."
   }
   validation {
     condition = var.cidr_allow_ingress_tfe_admin_console != null ? alltrue([

--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -94,6 +94,58 @@ resource "aws_lb_target_group" "nlb_443" {
   )
 }
 
+# Admin Console listener and target group for NLB
+resource "aws_lb_listener" "lb_nlb_admin_console" {
+  count = var.lb_type == "nlb" && !var.tfe_admin_console_disabled ? 1 : 0
+
+  load_balancer_arn = aws_lb.nlb[0].arn
+  port              = var.tfe_admin_https_port
+  protocol          = "TCP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.nlb_admin_console[0].arn
+  }
+}
+
+resource "aws_lb_target_group" "nlb_admin_console" {
+  count = var.lb_type == "nlb" && !var.tfe_admin_console_disabled ? 1 : 0
+
+  name     = "${var.friendly_name_prefix}-tfe-nlb-tg-${var.tfe_admin_https_port}"
+  protocol = "TCP"
+  port     = var.tfe_admin_https_port
+  vpc_id   = var.vpc_id
+
+  health_check {
+    protocol            = "HTTPS"
+    path                = local.tfe_image_tag_gte_1 ? "/api/v1/health/readiness" : "/_health_check"
+    port                = "443"
+    matcher             = "200"
+    healthy_threshold   = 5
+    unhealthy_threshold = 5
+    timeout             = 10
+    interval            = 30
+  }
+
+  stickiness {
+    enabled = var.lb_stickiness_enabled
+    type    = "source_ip"
+  }
+
+  tags = merge(
+    { "Name" = "${var.friendly_name_prefix}-tfe-nlb-tg-${var.tfe_admin_https_port}" },
+    { "Description" = "Load balancer target group for TFE admin console traffic." },
+    var.common_tags
+  )
+}
+
+resource "aws_autoscaling_attachment" "tfe_asg_attachment_nlb_admin_console" {
+  count = var.lb_type == "nlb" && !var.tfe_admin_console_disabled ? 1 : 0
+
+  autoscaling_group_name = aws_autoscaling_group.tfe.name
+  lb_target_group_arn    = aws_lb_target_group.nlb_admin_console[0].arn
+}
+
 #------------------------------------------------------------------------------
 # Application load balancer (ALB)
 #------------------------------------------------------------------------------
@@ -156,6 +208,55 @@ resource "aws_lb_target_group" "alb_443" {
   )
 }
 
+# Admin Console listener and target group for ALB
+resource "aws_lb_listener" "alb_admin_console" {
+  count = var.lb_type == "alb" && !var.tfe_admin_console_disabled ? 1 : 0
+
+  load_balancer_arn = aws_lb.alb[0].arn
+  port              = var.tfe_admin_https_port
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = var.tfe_alb_tls_certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.alb_admin_console[0].arn
+  }
+}
+
+resource "aws_lb_target_group" "alb_admin_console" {
+  count = var.lb_type == "alb" && !var.tfe_admin_console_disabled ? 1 : 0
+
+  name     = "${var.friendly_name_prefix}-tfe-alb-tg-${var.tfe_admin_https_port}"
+  port     = var.tfe_admin_https_port
+  protocol = "HTTPS"
+  vpc_id   = var.vpc_id
+
+  health_check {
+    protocol            = "HTTPS"
+    path                = local.tfe_image_tag_gte_1 ? "/api/v1/health/readiness" : "/_health_check"
+    port                = "443"
+    healthy_threshold   = 2
+    unhealthy_threshold = 7
+    timeout             = 5
+    interval            = 30
+    matcher             = 200
+  }
+
+  tags = merge(
+    { "Name" = "${var.friendly_name_prefix}-tfe-alb-tg-${var.tfe_admin_https_port}" },
+    { "Description" = "Load balancer target group for TFE admin console traffic." },
+    var.common_tags
+  )
+}
+
+resource "aws_autoscaling_attachment" "tfe_asg_attachment_alb_admin_console" {
+  count = var.lb_type == "alb" && !var.tfe_admin_console_disabled ? 1 : 0
+
+  autoscaling_group_name = aws_autoscaling_group.tfe.name
+  lb_target_group_arn    = aws_lb_target_group.alb_admin_console[0].arn
+}
+
 #------------------------------------------------------------------------------
 # Security groups
 #------------------------------------------------------------------------------
@@ -203,4 +304,31 @@ resource "aws_security_group_rule" "lb_allow_egress_all" {
   description = "Allow all traffic outbound from the TFE load balancer."
 
   security_group_id = aws_security_group.lb_allow_egress.id
+}
+
+# Admin Console ingress rules for load balancer
+resource "aws_security_group_rule" "lb_allow_ingress_admin_console_from_cidr" {
+  count = !var.tfe_admin_console_disabled ? 1 : 0
+
+  type        = "ingress"
+  from_port   = var.tfe_admin_https_port
+  to_port     = var.tfe_admin_https_port
+  protocol    = "tcp"
+  cidr_blocks = var.cidr_allow_ingress_tfe_admin_console
+  description = "Allow TCP/${var.tfe_admin_https_port} (Admin Console HTTPS) inbound to TFE load balancer from specified CIDR ranges."
+
+  security_group_id = aws_security_group.lb_allow_ingress.id
+}
+
+resource "aws_security_group_rule" "lb_allow_ingress_admin_console_from_ec2" {
+  count = !var.tfe_admin_console_disabled ? 1 : 0
+
+  type                     = "ingress"
+  from_port                = var.tfe_admin_https_port
+  to_port                  = var.tfe_admin_https_port
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.ec2_allow_ingress.id
+  description              = "Allow TCP/${var.tfe_admin_https_port} (Admin Console HTTPS) inbound to TFE load balancer from TFE EC2 security group."
+
+  security_group_id = aws_security_group.lb_allow_ingress.id
 }

--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -315,7 +315,7 @@ resource "aws_security_group_rule" "lb_allow_ingress_admin_console_from_cidr" {
   to_port     = var.tfe_admin_https_port
   protocol    = "tcp"
   cidr_blocks = var.cidr_allow_ingress_tfe_admin_console
-  description = "Allow TCP/${var.tfe_admin_https_port} (Admin Console HTTPS) inbound to TFE load balancer from specified CIDR ranges."
+  description = "Allow TCP (Admin Console HTTPS) inbound to TFE load balancer from specified CIDR ranges."
 
   security_group_id = aws_security_group.lb_allow_ingress.id
 }
@@ -328,7 +328,7 @@ resource "aws_security_group_rule" "lb_allow_ingress_admin_console_from_ec2" {
   to_port                  = var.tfe_admin_https_port
   protocol                 = "tcp"
   source_security_group_id = aws_security_group.ec2_allow_ingress.id
-  description              = "Allow TCP/${var.tfe_admin_https_port} (Admin Console HTTPS) inbound to TFE load balancer from TFE EC2 security group."
+  description              = "Allow TCP (Admin Console HTTPS) inbound to TFE load balancer from TFE EC2 security group."
 
   security_group_id = aws_security_group.lb_allow_ingress.id
 }

--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -308,14 +308,27 @@ resource "aws_security_group_rule" "lb_allow_egress_all" {
 
 # Admin Console ingress rules for load balancer
 resource "aws_security_group_rule" "lb_allow_ingress_admin_console_from_cidr" {
-  count = !var.tfe_admin_console_disabled ? 1 : 0
+  count = !var.tfe_admin_console_disabled && length([for cidr in var.cidr_allow_ingress_tfe_admin_console : cidr if !can(regex(":", cidr))]) > 0 ? 1 : 0
 
   type        = "ingress"
   from_port   = var.tfe_admin_https_port
   to_port     = var.tfe_admin_https_port
   protocol    = "tcp"
-  cidr_blocks = var.cidr_allow_ingress_tfe_admin_console
+  cidr_blocks = [for cidr in var.cidr_allow_ingress_tfe_admin_console : cidr if !can(regex(":", cidr))]
   description = "Allow TCP (Admin Console HTTPS) inbound to TFE load balancer from specified CIDR ranges."
+
+  security_group_id = aws_security_group.lb_allow_ingress.id
+}
+
+resource "aws_security_group_rule" "lb_allow_ingress_admin_console_from_ipv6_cidr" {
+  count = !var.tfe_admin_console_disabled && length([for cidr in var.cidr_allow_ingress_tfe_admin_console : cidr if can(regex(":", cidr))]) > 0 ? 1 : 0
+
+  type             = "ingress"
+  from_port        = var.tfe_admin_https_port
+  to_port          = var.tfe_admin_https_port
+  protocol         = "tcp"
+  ipv6_cidr_blocks = [for cidr in var.cidr_allow_ingress_tfe_admin_console : cidr if can(regex(":", cidr))]
+  description      = "Allow TCP (Admin Console HTTPS) inbound to TFE load balancer from specified IPv6 CIDR ranges."
 
   security_group_id = aws_security_group.lb_allow_ingress.id
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -84,3 +84,12 @@ output "elasticache_replication_group_primary_endpoint_address" {
   value       = try(aws_elasticache_replication_group.redis_cluster[0].primary_endpoint_address, null)
   description = "Primary endpoint address of ElastiCache Replication Group (Redis) cluster."
 }
+
+#------------------------------------------------------------------------------
+# Admin Console
+#------------------------------------------------------------------------------
+
+output "tfe_admin_console_url_pattern" {
+  value       = !var.tfe_admin_console_disabled ? "https://${var.tfe_fqdn}:${var.tfe_admin_https_port}" : null
+  description = "URL pattern to access the TFE Admin Console. Only applicable if `tfe_admin_console_disabled` is set to false."
+}

--- a/templates/tfe_user_data.sh.tpl
+++ b/templates/tfe_user_data.sh.tpl
@@ -289,7 +289,10 @@ services:
 %{ endif ~}
       TFE_IPV6_ENABLED: ${tfe_ipv6_enabled}
       TFE_ADMIN_HTTPS_PORT: ${tfe_admin_https_port}
-
+%{ if tfe_admin_console_disabled ~}
+      # Admin Console settings
+      TFE_ADMIN_CONSOLE_DISABLED: "true"
+%{ endif ~}
 %{ if tfe_hairpin_addressing ~}
     extra_hosts:
       - ${tfe_hostname}:$VM_PRIVATE_IP
@@ -305,6 +308,7 @@ services:
       - 80:${tfe_http_port}
       - 443:${tfe_https_port}
       - ${tfe_admin_https_port}:${tfe_admin_https_port}
+
 %{ if tfe_operational_mode == "active-active" ~}
       - 8201:8201
 %{ endif ~}
@@ -498,7 +502,11 @@ spec:
       value: ${tfe_ipv6_enabled}
     - name: "TFE_ADMIN_HTTPS_PORT"
       value: ${tfe_admin_https_port}
-
+%{ if !tfe_admin_console_disabled ~}
+    # Admin Console settings
+    - name: "TFE_ADMIN_CONSOLE_DISABLED"
+      value: "true"
+%{ endif ~}
     image: ${tfe_image_repository_url}/${tfe_image_name}:${tfe_image_tag}
     name: "terraform-enterprise"
     ports:

--- a/templates/tfe_user_data.sh.tpl
+++ b/templates/tfe_user_data.sh.tpl
@@ -502,8 +502,8 @@ spec:
       value: ${tfe_ipv6_enabled}
     - name: "TFE_ADMIN_HTTPS_PORT"
       value: ${tfe_admin_https_port}
-%{ if !tfe_admin_console_disabled ~}
-    # Admin Console settings
+%{ if tfe_admin_console_disabled ~}
+    # Admin Console settings defaults to false, so only set environment variable to disable Admin Console if 'tfe_admin_console_disabled' is set to true
     - name: "TFE_ADMIN_CONSOLE_DISABLED"
       value: "true"
 %{ endif ~}

--- a/templates/tfe_user_data.sh.tpl
+++ b/templates/tfe_user_data.sh.tpl
@@ -503,7 +503,6 @@ spec:
     - name: "TFE_ADMIN_HTTPS_PORT"
       value: ${tfe_admin_https_port}
 %{ if tfe_admin_console_disabled ~}
-    # Admin Console settings defaults to false, so only set environment variable to disable Admin Console if 'tfe_admin_console_disabled' is set to true
     - name: "TFE_ADMIN_CONSOLE_DISABLED"
       value: "true"
 %{ endif ~}

--- a/variables.tf
+++ b/variables.tf
@@ -273,7 +273,31 @@ variable "tfe_admin_https_port" {
     error_message = "`tfe_admin_https_port` must not be the same as `tfe_https_port` or `tfe_http_port` to avoid conflicts."
   }
 }
+#------------------------------------------------------------------------------
+# Admin Console
+#------------------------------------------------------------------------------
+variable "tfe_admin_console_disabled" {
+  type        = bool
+  description = "Boolean to disable the TFE Admin Console for advanced troubleshooting and diagnostics. When disabled, the admin console will not be accessible."
+  default     = true
+}
 
+variable "cidr_allow_ingress_tfe_admin_console" {
+  type        = list(string)
+  description = "List of CIDR ranges to allow ingress traffic on the admin console port. Required when `tfe_admin_console_disabled` is `false`."
+  default     = null
+
+  validation {
+    condition     = !var.tfe_admin_console_disabled ? var.cidr_allow_ingress_tfe_admin_console != null : true
+    error_message = "Value must be set when `tfe_admin_console_disabled` is `false`. Admin console requires explicit CIDR ranges for security."
+  }
+  validation {
+    condition = var.cidr_allow_ingress_tfe_admin_console != null ? alltrue([
+      for cidr in var.cidr_allow_ingress_tfe_admin_console : can(cidrhost(cidr, 0))
+    ]) : true
+    error_message = "All values must be valid CIDR notation (e.g., '10.0.0.0/8')."
+  }
+}
 #------------------------------------------------------------------------------
 # Networking
 #------------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -288,8 +288,8 @@ variable "cidr_allow_ingress_tfe_admin_console" {
   default     = null
 
   validation {
-    condition     = !var.tfe_admin_console_disabled ? var.cidr_allow_ingress_tfe_admin_console != null : true
-    error_message = "Value must be set when `tfe_admin_console_disabled` is `false`. Admin console requires explicit CIDR ranges for security."
+    condition     = !var.tfe_admin_console_disabled ? (var.cidr_allow_ingress_tfe_admin_console != null && length(var.cidr_allow_ingress_tfe_admin_console) > 0) : true
+    error_message = "Value must be set to a non-empty list when `tfe_admin_console_disabled` is `false`. Admin console requires at least one explicit CIDR range for security."
   }
   validation {
     condition = var.cidr_allow_ingress_tfe_admin_console != null ? alltrue([


### PR DESCRIPTION
This pull request introduces support for enabling or disabling the TFE Admin Console, along with associated security group rules, input variables, and documentation updates. It also includes improvements to documentation formatting and minor code style changes for clarity.

**Admin Console Feature Enhancements:**

* Added new input variable `tfe_admin_console_disabled` to allow users to enable or disable the TFE Admin Console for advanced troubleshooting and diagnostics. 
* Introduced new input variable `cidr_allow_ingress_tfe_admin_console` to specify allowed CIDR ranges for admin console ingress.
* Implemented new security group rules in `compute.tf` for admin console ingress (both IPv4 and IPv6) and egress, conditionally created based on the admin console state. 
* Updated outputs to include `tfe_admin_console_url_pattern` for referencing the admin console URL when enabled.

**Documentation and Usability Improvements:**

* Updated the `README.md` to document new variables, outputs, and resources related to the admin console

**Code Quality and Style:**

These changes collectively improve the module's flexibility, security, and documentation clarity for users deploying Terraform Enterprise in AWS.

## Description

- Add resources etc to implement admin console 
- defaults to `disbaled = true` so not to force deployment on part of consumer

## Related issue
NA

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How has this been tested?
- deploy and test on default ports on ubuntu

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional notes

moved from exernal fork
