### PR TITLE
feat(secondary-hostname): add secondary hostname support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Terraform Enterprise HVD on AWS EC2
 
-Terraform module aligned with HashiCorp Validated Designs (HVD) to deploy Terraform Enterprise (TFE) on Amazon Web Services (AWS) using EC2 instances with a container runtime. This module defaults to deploying TFE in the `active-active` [operational mode](https://developer.hashicorp.com/terraform/enterprise/flexible-deployments/install/operation-modes), but `external` is also supported. Docker and Podman are the supported container runtimes.
+Terraform module aligned with HashiCorp Validated Designs (HVD) to deploy Terraform Enterprise (TFE) on Amazon Web Services (AWS) using EC2 instances with a container runtime. This module defaults to deploying TFE in the `active-active` [operational mode](https://developer.hashicorp.com/terraform/enterprise/flexible-deployments/install/operation-modes), but `external` is also supported. Docker and Podman are the supported container runtimes. Optional secondary-hostname support is included for external integrations such as OIDC, VCS, and run tasks.
 
 ![TFE architecture](https://developer.hashicorp.com/.extracted/hvd/img/terraform/solution-design-guides/tfe/architecture-logical-active-active.png)
 
@@ -20,12 +20,15 @@ Terraform module aligned with HashiCorp Validated Designs (HVD) to deploy Terraf
 
 - AWS VPC ID and the following subnets:
   - Load balancer subnet IDs (can be the same as EC2 subnets if desirable)
+  - (Optional) Secondary public load balancer subnet IDs when creating a managed secondary hostname NLB
   - EC2 (compute) subnet IDs
   - RDS (database) subnet IDs
   - Redis subnet IDs (can be the same as RDS subnets if desirable)
 - (Optional) S3 VPC endpoint configured within VPC
 - (Optional) AWS Route53 hosted zone for TFE DNS record creation
+- (Optional) AWS public Route53 hosted zone for a managed secondary TFE DNS record
 - Chosen fully qualified domain name (FQDN) for your TFE instance (_e.g._ `tfe.aws.example.com`)
+- (Optional) Chosen secondary externally resolvable FQDN for TFE integrations (_e.g._ `tfe-external.aws.example.com`)
 
 >📝 Note: It is recommended to specify a minimum of two subnets for each subnet input to enable high availability.
 
@@ -45,6 +48,7 @@ Terraform module aligned with HashiCorp Validated Designs (HVD) to deploy Terraf
 - TLS certificate authority (CA) bundle (_e.g._ `ca_bundle.pem`) corresponding with the CA that issues your TFE TLS certificates
   - CA bundle must be in PEM format
   - You may include additional certificate chains corresponding to external systems that TFE will make outbound connections to (_e.g._ your self-hosted VCS, if its certificate was issued by a different CA than your TFE certificate).
+- (Optional) Separate TLS certificate, private key, and CA bundle for `tfe_hostname_secondary` when enabling a secondary hostname
 
 >📝 Note: All three of these files will be created as secrets in AWS Secrets Manager per the next section.
 
@@ -59,6 +63,9 @@ The following _bootstrap_ secrets stored in **AWS Secrets Manager** in order to 
 - **TFE TLS certificate** - file in PEM format, base64-encoded into a string, and stored as a plaintext secret
 - **TFE TLS certificate private key** - file in PEM format, base64-encoded into a string, and stored as a plaintext secret
 - **TFE TLS CA bundle** - file in PEM format , base64-encoded into a string, and stored as a plaintext secret
+- **Secondary TFE TLS certificate** - optional file in PEM format, base64-encoded into a string, and stored as a plaintext secret
+- **Secondary TFE TLS certificate private key** - optional file in PEM format, base64-encoded into a string, and stored as a plaintext secret
+- **Secondary TFE TLS CA bundle** - optional file in PEM format, base64-encoded into a string, and stored as a plaintext secret
 
 >📝 Note: See the [TFE bootstrap secrets](./docs/tfe-bootstrap-secrets.md) doc for more details on how these secrets should be stored in AWS Secrets Manager.
 
@@ -170,6 +177,12 @@ One of the following logging destinations:
 
 9.  Follow the steps to [create the TFE initial admin user](https://developer.hashicorp.com/terraform/enterprise/flexible-deployments/install/initial-admin-user).
 
+## Secondary hostname support
+
+This module can optionally configure the Terraform Enterprise runtime with `TFE_HOSTNAME_SECONDARY` plus the documented hostname-choice settings for OIDC, VCS, and run tasks. When you want the module to manage the external endpoint as well, you can also create a dedicated public secondary NLB and Route53 alias record with its own CIDR filtering while leaving the primary hostname path unchanged.
+
+When `tfe_hostname_secondary` is set, provide matching secondary TLS secrets so the TFE instance can serve both hostnames. If you choose to have the module manage the external endpoint, ensure the secondary hostname resolves publicly and that `secondary_lb_subnet_ids` point to public subnets.
+
 ## Docs
 
 Below are links to various docs related to the customization and management of your TFE deployment:
@@ -222,15 +235,19 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | [aws_launch_template.tfe](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
 | [aws_lb.alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
 | [aws_lb.nlb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
+| [aws_lb.secondary_nlb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
 | [aws_lb_listener.alb_443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
 | [aws_lb_listener.lb_nlb_443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_listener.secondary_nlb_443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
 | [aws_lb_target_group.alb_443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
 | [aws_lb_target_group.nlb_443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_lb_target_group.secondary_nlb_443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
 | [aws_rds_cluster.tfe](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster) | resource |
 | [aws_rds_cluster_instance.tfe](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_instance) | resource |
 | [aws_rds_cluster_parameter_group.tfe](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_parameter_group) | resource |
 | [aws_rds_global_cluster.tfe](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_global_cluster) | resource |
 | [aws_route53_record.alias_record](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.secondary_alias_record](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_s3_bucket.tfe](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_public_access_block.tfe](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_replication_configuration.tfe](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_replication_configuration) | resource |
@@ -242,6 +259,8 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | [aws_security_group.lb_allow_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.rds_allow_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.redis_allow_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group.secondary_lb_allow_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group.secondary_lb_allow_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group_rule.ec2_allow_cidr_ingress_tfe_metrics_http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ec2_allow_cidr_ingress_tfe_metrics_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ec2_allow_egress_all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
@@ -256,12 +275,16 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | [aws_security_group_rule.ec2_allow_egress_vault](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ec2_allow_ingress_ssh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ec2_allow_ingress_tfe_https_from_lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ec2_allow_ingress_tfe_https_from_secondary_lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ec2_allow_ingress_vault](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.lb_allow_egress_all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.lb_allow_ingress_tfe_https_from_cidr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.lb_allow_ingress_tfe_https_from_ec2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.rds_allow_ingress_from_ec2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.redis_allow_ingress_from_ec2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.secondary_lb_allow_egress_all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.secondary_lb_allow_ingress_tfe_https_from_cidr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.secondary_lb_allow_ingress_tfe_https_from_ec2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_ami.al2023](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_ami.rhel](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_ami.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
@@ -287,12 +310,16 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | [aws_iam_policy_document.tfe_ec2_get_enc_password_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.tfe_ec2_get_license_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.tfe_ec2_get_rds_password_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.tfe_ec2_get_tls_ca_bundle_secondary_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.tfe_ec2_get_tls_ca_bundle_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.tfe_ec2_get_tls_cert_secondary_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.tfe_ec2_get_tls_cert_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.tfe_ec2_get_tls_privkey_secondary_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.tfe_ec2_get_tls_privkey_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_route53_zone.tfe](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
+| [aws_route53_zone.tfe_secondary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 | [aws_s3_bucket.log_fwd](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
 | [aws_secretsmanager_secret_version.tfe_database_password](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [aws_secretsmanager_secret_version.tfe_redis_password](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
@@ -325,10 +352,13 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | <a name="input_cidr_allow_ingress_tfe_443"></a> [cidr\_allow\_ingress\_tfe\_443](#input\_cidr\_allow\_ingress\_tfe\_443) | List of CIDR ranges allowed to access the TFE application over HTTPS (port 443). | `list(string)` | <pre>[<br/>  "0.0.0.0/0"<br/>]</pre> | no |
 | <a name="input_cidr_allow_ingress_tfe_metrics_http"></a> [cidr\_allow\_ingress\_tfe\_metrics\_http](#input\_cidr\_allow\_ingress\_tfe\_metrics\_http) | List of CIDR ranges to allow TCP/9090 (HTTP) inbound to metrics endpoint on TFE EC2 instances. | `list(string)` | `null` | no |
 | <a name="input_cidr_allow_ingress_tfe_metrics_https"></a> [cidr\_allow\_ingress\_tfe\_metrics\_https](#input\_cidr\_allow\_ingress\_tfe\_metrics\_https) | List of CIDR ranges to allow TCP/9091 (HTTPS) inbound to metrics endpoint on TFE EC2 instances. | `list(string)` | `null` | no |
+| <a name="input_cidr_allow_ingress_tfe_secondary_443"></a> [cidr\_allow\_ingress\_tfe\_secondary\_443](#input\_cidr\_allow\_ingress\_tfe\_secondary\_443) | List of CIDR ranges allowed to access the secondary TFE public Network Load Balancer (NLB) over HTTPS (port 443). | `list(string)` | <pre>[<br/>  "0.0.0.0/0"<br/>]</pre> | no |
 | <a name="input_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#input\_cloudwatch\_log\_group\_name) | Name of CloudWatch Log Group to configure as log forwarding destination. Only valid when `tfe_log_forwarding_enabled` is `true`. | `string` | `null` | no |
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | Map of common tags for all taggable AWS resources. | `map(string)` | `{}` | no |
 | <a name="input_container_runtime"></a> [container\_runtime](#input\_container\_runtime) | Container runtime to use for TFE. Supported values are `docker` or `podman`. | `string` | `"docker"` | no |
 | <a name="input_create_route53_tfe_dns_record"></a> [create\_route53\_tfe\_dns\_record](#input\_create\_route53\_tfe\_dns\_record) | Boolean to create Route53 Alias Record for `tfe_hostname` resolving to Load Balancer DNS name. If `true`, `route53_tfe_hosted_zone_name` is also required. | `bool` | `false` | no |
+| <a name="input_create_route53_tfe_secondary_dns_record"></a> [create\_route53\_tfe\_secondary\_dns\_record](#input\_create\_route53\_tfe\_secondary\_dns\_record) | Boolean to create a Route53 Alias record for `tfe_hostname_secondary` resolving to the secondary public Network Load Balancer (NLB). | `bool` | `false` | no |
+| <a name="input_create_secondary_tfe_nlb"></a> [create\_secondary\_tfe\_nlb](#input\_create\_secondary\_tfe\_nlb) | Boolean to create a dedicated public Network Load Balancer (NLB) for `tfe_hostname_secondary`. | `bool` | `false` | no |
 | <a name="input_custom_fluent_bit_config"></a> [custom\_fluent\_bit\_config](#input\_custom\_fluent\_bit\_config) | Custom Fluent Bit configuration for log forwarding. Only valid when `tfe_log_forwarding_enabled` is `true` and `log_fwd_destination_type` is `custom`. | `string` | `null` | no |
 | <a name="input_custom_tfe_startup_script_template"></a> [custom\_tfe\_startup\_script\_template](#input\_custom\_tfe\_startup\_script\_template) | Filename of a custom TFE startup script template to use in place of of the built-in user\_data script. The file must exist within a directory named './templates' in your current working directory. | `string` | `null` | no |
 | <a name="input_docker_version"></a> [docker\_version](#input\_docker\_version) | Version of Docker to install on TFE EC2 instances. Not applicable to Amazon Linux 2023 distribution (when `ec2_os_distro` is `al2023`). | `string` | `"28.0.1"` | no |
@@ -385,6 +415,8 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | <a name="input_redis_transit_encryption_enabled"></a> [redis\_transit\_encryption\_enabled](#input\_redis\_transit\_encryption\_enabled) | Boolean to enable TLS encryption between TFE and the Redis cluster. | `bool` | `true` | no |
 | <a name="input_route53_tfe_hosted_zone_is_private"></a> [route53\_tfe\_hosted\_zone\_is\_private](#input\_route53\_tfe\_hosted\_zone\_is\_private) | Boolean indicating if `route53_tfe_hosted_zone_name` is a private hosted zone. | `bool` | `false` | no |
 | <a name="input_route53_tfe_hosted_zone_name"></a> [route53\_tfe\_hosted\_zone\_name](#input\_route53\_tfe\_hosted\_zone\_name) | Route53 Hosted Zone name to create `tfe_hostname` Alias record in. Required if `create_route53_tfe_dns_record` is `true`. | `string` | `null` | no |
+| <a name="input_route53_tfe_secondary_hosted_zone_is_private"></a> [route53\_tfe\_secondary\_hosted\_zone\_is\_private](#input\_route53\_tfe\_secondary\_hosted\_zone\_is\_private) | Boolean indicating if `route53_tfe_secondary_hosted_zone_name` is a private hosted zone. Secondary hostname DNS must be public when created by this module. | `bool` | `false` | no |
+| <a name="input_route53_tfe_secondary_hosted_zone_name"></a> [route53\_tfe\_secondary\_hosted\_zone\_name](#input\_route53\_tfe\_secondary\_hosted\_zone\_name) | Route53 Hosted Zone name to create the `tfe_hostname_secondary` alias record in. Required if `create_route53_tfe_secondary_dns_record` is `true`. | `string` | `null` | no |
 | <a name="input_s3_destination_bucket_arn"></a> [s3\_destination\_bucket\_arn](#input\_s3\_destination\_bucket\_arn) | ARN of destination S3 bucket for cross-region replication configuration. Bucket should already exist in secondary region. Required when `s3_enable_bucket_replication` is `true`. | `string` | `""` | no |
 | <a name="input_s3_destination_bucket_kms_key_arn"></a> [s3\_destination\_bucket\_kms\_key\_arn](#input\_s3\_destination\_bucket\_kms\_key\_arn) | ARN of KMS key of destination S3 bucket for cross-region replication configuration if it is encrypted with a customer managed key (CMK). | `string` | `null` | no |
 | <a name="input_s3_enable_bucket_replication"></a> [s3\_enable\_bucket\_replication](#input\_s3\_enable\_bucket\_replication) | Boolean to enable cross-region replication for TFE S3 bucket. An `s3_destination_bucket_arn` is required when `true`. | `bool` | `false` | no |
@@ -393,6 +425,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | <a name="input_s3_force_destroy"></a> [s3\_force\_destroy](#input\_s3\_force\_destroy) | Boolean to enable force destruction of S3 bucket and all objects within it. When `true`, the bucket can be destroyed even if it contains objects. | `bool` | `false` | no |
 | <a name="input_s3_kms_key_arn"></a> [s3\_kms\_key\_arn](#input\_s3\_kms\_key\_arn) | ARN of KMS customer managed key (CMK) to encrypt TFE S3 bucket with. | `string` | `null` | no |
 | <a name="input_s3_log_fwd_bucket_name"></a> [s3\_log\_fwd\_bucket\_name](#input\_s3\_log\_fwd\_bucket\_name) | Name of S3 bucket to configure as log forwarding destination. Only valid when `tfe_log_forwarding_enabled` is `true`. | `string` | `null` | no |
+| <a name="input_secondary_lb_subnet_ids"></a> [secondary\_lb\_subnet\_ids](#input\_secondary\_lb\_subnet\_ids) | List of public subnet IDs to use for the secondary Network Load Balancer (NLB). Required when `create_secondary_tfe_nlb` is `true`. | `list(string)` | `null` | no |
 | <a name="input_tfe_admin_https_port"></a> [tfe\_admin\_https\_port](#input\_tfe\_admin\_https\_port) | Port the TFE application container listens on for [system (admin) API endpoints](https://developer.hashicorp.com/terraform/enterprise/api-docs#system-endpoints-overview) HTTPS traffic. This value is used for both the host and container port. | `number` | `9443` | no |
 | <a name="input_tfe_alb_tls_certificate_arn"></a> [tfe\_alb\_tls\_certificate\_arn](#input\_tfe\_alb\_tls\_certificate\_arn) | ARN of existing TFE TLS certificate imported in ACM to be used for application load balancer (ALB) HTTPS listeners. Required when `lb_type` is `alb`. | `string` | `null` | no |
 | <a name="input_tfe_capacity_concurrency"></a> [tfe\_capacity\_concurrency](#input\_tfe\_capacity\_concurrency) | Maximum number of concurrent Terraform runs to allow on a TFE node. | `number` | `10` | no |
@@ -403,6 +436,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | <a name="input_tfe_database_parameters"></a> [tfe\_database\_parameters](#input\_tfe\_database\_parameters) | PostgreSQL server parameters for the connection URI. Used to configure the PostgreSQL connection. | `string` | `"sslmode=require"` | no |
 | <a name="input_tfe_database_user"></a> [tfe\_database\_user](#input\_tfe\_database\_user) | Username for TFE RDS database cluster. | `string` | `"tfe"` | no |
 | <a name="input_tfe_hairpin_addressing"></a> [tfe\_hairpin\_addressing](#input\_tfe\_hairpin\_addressing) | Boolean to enable hairpin addressing for layer 4 load balancer with loopback prevention. Must be `true` when `lb_type` is `nlb` and `lb_is_internal` is `true`. | `bool` | `true` | no |
+| <a name="input_tfe_hostname_secondary"></a> [tfe\_hostname\_secondary](#input\_tfe\_hostname\_secondary) | Secondary externally resolvable fully qualified domain name (FQDN) for TFE integration traffic such as OIDC, VCS, or run tasks. | `string` | `null` | no |
 | <a name="input_tfe_http_port"></a> [tfe\_http\_port](#input\_tfe\_http\_port) | Port the TFE application container listens on for HTTP traffic. This is not the host port. | `number` | `8080` | no |
 | <a name="input_tfe_https_port"></a> [tfe\_https\_port](#input\_tfe\_https\_port) | Port the TFE application container listens on for HTTPS traffic. This is not the host port. | `number` | `8443` | no |
 | <a name="input_tfe_iact_subnets"></a> [tfe\_iact\_subnets](#input\_tfe\_iact\_subnets) | Comma-separated list of subnets in CIDR notation (e.g., `10.0.0.0/8,192.168.0.0/24`) that are allowed to retrieve the TFE initial admin creation token (IACT) via the API or web browser. Leave as `null` to disable IACT retrieval via the API from external clients. | `string` | `null` | no |
@@ -423,13 +457,19 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | <a name="input_tfe_object_storage_s3_access_key_id"></a> [tfe\_object\_storage\_s3\_access\_key\_id](#input\_tfe\_object\_storage\_s3\_access\_key\_id) | Access key ID for S3 bucket. Required when `tfe_object_storage_s3_use_instance_profile` is `false`. | `string` | `null` | no |
 | <a name="input_tfe_object_storage_s3_secret_access_key"></a> [tfe\_object\_storage\_s3\_secret\_access\_key](#input\_tfe\_object\_storage\_s3\_secret\_access\_key) | Secret access key for S3 bucket. Required when `tfe_object_storage_s3_use_instance_profile` is `false`. | `string` | `null` | no |
 | <a name="input_tfe_object_storage_s3_use_instance_profile"></a> [tfe\_object\_storage\_s3\_use\_instance\_profile](#input\_tfe\_object\_storage\_s3\_use\_instance\_profile) | Boolean to use TFE instance profile for S3 bucket access. If `false`, `tfe_object_storage_s3_access_key_id` and `tfe_object_storage_s3_secret_access_key` are required. | `bool` | `true` | no |
+| <a name="input_tfe_oidc_hostname_choice"></a> [tfe\_oidc\_hostname\_choice](#input\_tfe\_oidc\_hostname\_choice) | Hostname choice for TFE OIDC workload federation integrations. Supported values are `primary` and `secondary`. | `string` | `"primary"` | no |
 | <a name="input_tfe_operational_mode"></a> [tfe\_operational\_mode](#input\_tfe\_operational\_mode) | [Operational mode](https://developer.hashicorp.com/terraform/enterprise/flexible-deployments/install/operation-modes) for TFE. Valid values are `active-active` or `external`. | `string` | `"active-active"` | no |
 | <a name="input_tfe_redis_password_secret_arn"></a> [tfe\_redis\_password\_secret\_arn](#input\_tfe\_redis\_password\_secret\_arn) | ARN of AWS Secrets Manager secret for the TFE Redis password used to create Redis (Elasticache Replication Group) cluster. Secret type should be plaintext. Value of secret must be from 16 to 128 alphanumeric characters or symbols (excluding `@`, `"`, and `/`). | `string` | `null` | no |
 | <a name="input_tfe_run_pipeline_docker_network"></a> [tfe\_run\_pipeline\_docker\_network](#input\_tfe\_run\_pipeline\_docker\_network) | Docker network where the containers that execute Terraform runs will be created. The network must already exist, it will not be created automatically. Leave as `null` to use the default network created by TFE. | `string` | `null` | no |
 | <a name="input_tfe_run_pipeline_image"></a> [tfe\_run\_pipeline\_image](#input\_tfe\_run\_pipeline\_image) | Fully qualified container image reference for the Terraform default agent container (e.g., 'internal-registry.example.com/tfe-agent:latest'). This is referred to as the [TFE\_RUN\_PIPELINE\_IMAGE](https://developer.hashicorp.com/terraform/enterprise/deploy/reference/configuration#tfe_run_pipeline_image) and is the image that is used to execute Terraform runs when execution mode is set to remote. The container registry hosting this image must allow anonymous (unauthenticated) pulls. | `string` | `null` | no |
+| <a name="input_tfe_run_task_hostname_choice"></a> [tfe\_run\_task\_hostname\_choice](#input\_tfe\_run\_task\_hostname\_choice) | Hostname choice for TFE run task integrations. Supported values are `primary` and `secondary`. | `string` | `"primary"` | no |
+| <a name="input_tfe_tls_ca_bundle_secret_arn_secondary"></a> [tfe\_tls\_ca\_bundle\_secret\_arn\_secondary](#input\_tfe\_tls\_ca\_bundle\_secret\_arn\_secondary) | ARN of AWS Secrets Manager secret for the secondary TFE TLS certificate authority bundle in PEM format. Secret must be stored as a base64-encoded string. Secret type should be plaintext. | `string` | `null` | no |
+| <a name="input_tfe_tls_cert_secret_arn_secondary"></a> [tfe\_tls\_cert\_secret\_arn\_secondary](#input\_tfe\_tls\_cert\_secret\_arn\_secondary) | ARN of AWS Secrets Manager secret for the secondary TFE TLS certificate in PEM format. Secret must be stored as a base64-encoded string. Secret type should be plaintext. | `string` | `null` | no |
 | <a name="input_tfe_tls_enforce"></a> [tfe\_tls\_enforce](#input\_tfe\_tls\_enforce) | Boolean to enforce TLS. | `bool` | `false` | no |
+| <a name="input_tfe_tls_privkey_secret_arn_secondary"></a> [tfe\_tls\_privkey\_secret\_arn\_secondary](#input\_tfe\_tls\_privkey\_secret\_arn\_secondary) | ARN of AWS Secrets Manager secret for the secondary TFE TLS private key in PEM format. Secret must be stored as a base64-encoded string. Secret type should be plaintext. | `string` | `null` | no |
 | <a name="input_tfe_usage_reporting_opt_out"></a> [tfe\_usage\_reporting\_opt\_out](#input\_tfe\_usage\_reporting\_opt\_out) | Boolean to opt out of reporting TFE usage information to HashiCorp. | `bool` | `false` | no |
 | <a name="input_tfe_vault_disable_mlock"></a> [tfe\_vault\_disable\_mlock](#input\_tfe\_vault\_disable\_mlock) | Boolean to disable mlock for internal Vault. | `bool` | `false` | no |
+| <a name="input_tfe_vcs_hostname_choice"></a> [tfe\_vcs\_hostname\_choice](#input\_tfe\_vcs\_hostname\_choice) | Hostname choice for TFE version control system (VCS) integrations. Supported values are `primary` and `secondary`. | `string` | `"primary"` | no |
 
 ## Outputs
 
@@ -446,7 +486,9 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | <a name="output_s3_bucket_arn"></a> [s3\_bucket\_arn](#output\_s3\_bucket\_arn) | ARN of TFE S3 bucket. |
 | <a name="output_s3_bucket_name"></a> [s3\_bucket\_name](#output\_s3\_bucket\_name) | Name of TFE S3 bucket. |
 | <a name="output_s3_crr_iam_role_arn"></a> [s3\_crr\_iam\_role\_arn](#output\_s3\_crr\_iam\_role\_arn) | ARN of S3 cross-region replication IAM role. |
+| <a name="output_secondary_lb_dns_name"></a> [secondary\_lb\_dns\_name](#output\_secondary\_lb\_dns\_name) | DNS name of the secondary public Network Load Balancer (NLB). |
 | <a name="output_tfe_create_initial_admin_user_url"></a> [tfe\_create\_initial\_admin\_user\_url](#output\_tfe\_create\_initial\_admin\_user\_url) | URL to create TFE initial admin user. |
 | <a name="output_tfe_database_host"></a> [tfe\_database\_host](#output\_tfe\_database\_host) | PostgreSQL server endpoint in the format that TFE will connect to. |
+| <a name="output_tfe_secondary_url"></a> [tfe\_secondary\_url](#output\_tfe\_secondary\_url) | URL to access TFE external integrations based on value of `tfe_hostname_secondary` input. |
 | <a name="output_tfe_url"></a> [tfe\_url](#output\_tfe\_url) | URL to access TFE application based on value of `tfe_fqdn` input. |
 <!-- END_TF_DOCS -->

--- a/compute.tf
+++ b/compute.tf
@@ -42,34 +42,42 @@ locals {
   s3_no_proxy              = "${aws_s3_bucket.tfe.bucket_domain_name},${aws_s3_bucket.tfe.bucket_regional_domain_name}"
   secrets_manager_no_proxy = "secretsmanager.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}"
 
-  addl_no_proxy_base = join(",", [
+  addl_no_proxy_base = join(",", compact([
     "localhost",
     "127.0.0.1",
     "169.254.169.254",
     var.tfe_fqdn,
+    var.tfe_hostname_secondary,
     local.s3_no_proxy,
     local.secrets_manager_no_proxy
-  ])
+  ]))
 
   user_data_args = {
     # Bootstrap
-    aws_region                         = data.aws_region.current.name
-    tfe_license_secret_arn             = var.tfe_license_secret_arn
-    tfe_tls_cert_secret_arn            = var.tfe_tls_cert_secret_arn
-    tfe_tls_privkey_secret_arn         = var.tfe_tls_privkey_secret_arn
-    tfe_tls_ca_bundle_secret_arn       = var.tfe_tls_ca_bundle_secret_arn
-    tfe_encryption_password_secret_arn = var.tfe_encryption_password_secret_arn
-    tfe_image_repository_url           = var.tfe_image_repository_url
-    tfe_image_name                     = var.tfe_image_name
-    tfe_image_tag                      = var.tfe_image_tag
-    tfe_image_repository_username      = var.tfe_image_repository_username
-    tfe_image_repository_password      = var.tfe_image_repository_password == null ? "" : var.tfe_image_repository_password
-    container_runtime                  = var.container_runtime
-    docker_version                     = var.docker_version
+    aws_region                             = data.aws_region.current.name
+    tfe_license_secret_arn                 = var.tfe_license_secret_arn
+    tfe_tls_cert_secret_arn                = var.tfe_tls_cert_secret_arn
+    tfe_tls_privkey_secret_arn             = var.tfe_tls_privkey_secret_arn
+    tfe_tls_ca_bundle_secret_arn           = var.tfe_tls_ca_bundle_secret_arn
+    tfe_tls_cert_secret_arn_secondary      = var.tfe_tls_cert_secret_arn_secondary == null ? "" : var.tfe_tls_cert_secret_arn_secondary
+    tfe_tls_privkey_secret_arn_secondary   = var.tfe_tls_privkey_secret_arn_secondary == null ? "" : var.tfe_tls_privkey_secret_arn_secondary
+    tfe_tls_ca_bundle_secret_arn_secondary = var.tfe_tls_ca_bundle_secret_arn_secondary == null ? "" : var.tfe_tls_ca_bundle_secret_arn_secondary
+    tfe_encryption_password_secret_arn     = var.tfe_encryption_password_secret_arn
+    tfe_image_repository_url               = var.tfe_image_repository_url
+    tfe_image_name                         = var.tfe_image_name
+    tfe_image_tag                          = var.tfe_image_tag
+    tfe_image_repository_username          = var.tfe_image_repository_username
+    tfe_image_repository_password          = var.tfe_image_repository_password == null ? "" : var.tfe_image_repository_password
+    container_runtime                      = var.container_runtime
+    docker_version                         = var.docker_version
 
     # https://developer.hashicorp.com/terraform/enterprise/flexible-deployments/install/configuration
     # Application settings
     tfe_hostname                  = var.tfe_fqdn
+    tfe_hostname_secondary        = var.tfe_hostname_secondary == null ? "" : var.tfe_hostname_secondary
+    tfe_oidc_hostname_choice      = var.tfe_oidc_hostname_choice
+    tfe_vcs_hostname_choice       = var.tfe_vcs_hostname_choice
+    tfe_run_task_hostname_choice  = var.tfe_run_task_hostname_choice
     tfe_operational_mode          = var.tfe_operational_mode
     tfe_capacity_concurrency      = var.tfe_capacity_concurrency
     tfe_capacity_cpu              = var.tfe_capacity_cpu
@@ -107,12 +115,14 @@ locals {
     tfe_redis_use_tls  = var.tfe_operational_mode == "active-active" && var.redis_transit_encryption_enabled ? true : false
 
     # TLS settings
-    tfe_tls_cert_file      = "/etc/ssl/private/terraform-enterprise/cert.pem"
-    tfe_tls_key_file       = "/etc/ssl/private/terraform-enterprise/key.pem"
-    tfe_tls_ca_bundle_file = "/etc/ssl/private/terraform-enterprise/bundle.pem"
-    tfe_tls_enforce        = var.tfe_tls_enforce
-    tfe_tls_ciphers        = "" # Leave blank to use the default ciphers
-    tfe_tls_version        = "" # Leave blank to use both TLS v1.2 and TLS v1.3
+    tfe_tls_cert_file           = "/etc/ssl/private/terraform-enterprise/cert.pem"
+    tfe_tls_key_file            = "/etc/ssl/private/terraform-enterprise/key.pem"
+    tfe_tls_cert_file_secondary = "/etc/ssl/private/terraform-enterprise/ext_cert.pem"
+    tfe_tls_key_file_secondary  = "/etc/ssl/private/terraform-enterprise/ext_key.pem"
+    tfe_tls_ca_bundle_file      = "/etc/ssl/private/terraform-enterprise/bundle.pem"
+    tfe_tls_enforce             = var.tfe_tls_enforce
+    tfe_tls_ciphers             = "" # Leave blank to use the default ciphers
+    tfe_tls_version             = "" # Leave blank to use both TLS v1.2 and TLS v1.3
 
     # Observability settings
     tfe_log_forwarding_enabled = var.tfe_log_forwarding_enabled
@@ -240,7 +250,10 @@ resource "aws_autoscaling_group" "tfe" {
     version = "$Latest"
   }
 
-  target_group_arns = [var.lb_type == "alb" ? aws_lb_target_group.alb_443[0].arn : aws_lb_target_group.nlb_443[0].arn]
+  target_group_arns = concat(
+    [var.lb_type == "alb" ? aws_lb_target_group.alb_443[0].arn : aws_lb_target_group.nlb_443[0].arn],
+    local.secondary_lb_target_group_arns
+  )
 
   tag {
     key                 = "Name"

--- a/docs/deployment-customizations.md
+++ b/docs/deployment-customizations.md
@@ -20,6 +20,33 @@ This module supports creating a load balancer with either and `internal` or `int
 lb_is_internal = false
 ```
 
+### Secondary hostname for external integrations
+
+This module can optionally configure Terraform Enterprise with a secondary hostname for external-facing integrations. Set the secondary hostname itself and choose whether OIDC, VCS, and run-task integrations should use the primary or secondary hostname:
+
+```hcl
+tfe_hostname_secondary       = "tfe-external.example.com"
+tfe_oidc_hostname_choice     = "secondary"
+tfe_vcs_hostname_choice      = "secondary"
+tfe_run_task_hostname_choice = "secondary"
+```
+
+When `tfe_hostname_secondary` is set, you must also provide secondary TLS certificate, private key, and CA bundle secrets through the corresponding `*_secondary` module inputs.
+
+### Secondary public NLB
+
+If you want this module to manage the secondary external endpoint, enable the optional secondary public NLB. This creates a dedicated public NLB, keeps CIDR filtering separate from the primary load balancer, and can optionally create a public Route53 alias record:
+
+```hcl
+create_secondary_tfe_nlb                = true
+secondary_lb_subnet_ids                 = ["subnet-public-a", "subnet-public-b"]
+cidr_allow_ingress_tfe_secondary_443    = ["203.0.113.0/24"]
+create_route53_tfe_secondary_dns_record = true
+route53_tfe_secondary_hosted_zone_name  = "example.com"
+```
+
+>📝 Note: The managed secondary hostname path is always public-facing. Use public subnets for `secondary_lb_subnet_ids` and a public Route53 hosted zone for `route53_tfe_secondary_hosted_zone_name`.
+
 ## DNS
 
 This module supports creating an _alias_ record in AWS Route53 for the TFE FQDN to resolve to the load balancer DNS name. To do so, the following module input variables may be set:
@@ -111,6 +138,7 @@ If either `http_proxy` or `https_proxy` (or both) are set, the module automatica
 - `127.0.0.1`
 - `169.254.169.254`
 - Value of `var.tfe_fqdn`
+- Value of `var.tfe_hostname_secondary` when configured
 - EC2 instance private IP address
 - TFE S3 bucket regional domain name (_e.g.,_ `<tfe-s3-bucket-name>.s3.<aws-region>.amazonaws.com`)
 - Regional AWS Secrets Manager endpoint (_e.g.,_ `secretsmanager.<aws-region>.amazonaws.com`)

--- a/docs/tfe-bootstrap-secrets.md
+++ b/docs/tfe-bootstrap-secrets.md
@@ -11,6 +11,9 @@ This document contains a table of the TFE _bootstrap_ secrets to be stored in AW
 | TFE TLS certificate (base64-encoded)             | Plaintext secret | `tfe_tls_cert_secret_arn`            |
 | TFE TLS certificate private key (base64-encoded) | Plaintext secret | `tfe_tls_privkey_secret_arn`         |
 | TFE TLS CA bundle (base64-encoded)               | Plaintext secret | `tfe_tls_ca_bundle_secret_arn`       |
+| Secondary TFE TLS certificate (base64-encoded)   | Plaintext secret | `tfe_tls_cert_secret_arn_secondary`  |
+| Secondary TFE TLS private key (base64-encoded)   | Plaintext secret | `tfe_tls_privkey_secret_arn_secondary` |
+| Secondary TFE TLS CA bundle (base64-encoded)     | Plaintext secret | `tfe_tls_ca_bundle_secret_arn_secondary` |
 
 ## Formatting
 
@@ -44,6 +47,7 @@ cat terraform.hclic
 - Start off with your certificate files in PEM format
 - These values should be base64-encoded
 - Ensure your command line interface (CLI) does not automatically inject new line characters during the base64-encoding
+- The secondary TLS secrets are only required when `tfe_hostname_secondary` is set
 
 Example on macOS Terminal:
 

--- a/docs/tfe-cert-rotation.md
+++ b/docs/tfe-cert-rotation.md
@@ -4,18 +4,22 @@ One of the required prerequisites to deploying this module is storing base64-enc
 
 ## Secrets
 
-| Certificate file    | Module input variable        |
-|---------------------|------------------------------|
-| TFE TLS certificate | `tfe_tls_cert_secret_arn`    |
-| TFE TLS private key | `tfe_tls_privkey_secret_arn` |
+| Certificate file              | Module input variable                 |
+|-------------------------------|---------------------------------------|
+| TFE TLS certificate           | `tfe_tls_cert_secret_arn`             |
+| TFE TLS private key           | `tfe_tls_privkey_secret_arn`          |
+| TFE TLS CA bundle             | `tfe_tls_ca_bundle_secret_arn`        |
+| Secondary TFE TLS certificate | `tfe_tls_cert_secret_arn_secondary`   |
+| Secondary TFE TLS private key | `tfe_tls_privkey_secret_arn_secondary` |
+| Secondary TFE TLS CA bundle   | `tfe_tls_ca_bundle_secret_arn_secondary` |
 
 ## Procedure
 
-Follow these steps to rotate the certificates for your TFE instance.
+Follow these steps to rotate the certificates for your TFE instance. If `tfe_hostname_secondary` is configured, rotate the secondary certificate materials during the same maintenance window.
 
-1. Obtain your new TFE TLS certificate file and private key file, both in PEM format.
+1. Obtain your new TFE TLS certificate file and private key file, both in PEM format. If applicable, also obtain the replacement CA bundle and the secondary hostname certificate materials.
 
-1. Update the values of the existing secrets in AWS Secrets Manager (`tfe_tls_cert_secret_arn` and `tfe_tls_privkey_secret_arn`, respectively). If you need assistance base64-encoding the files into strings prior to updating the secrets, see the examples below:
+1. Update the values of the existing secrets in AWS Secrets Manager (`tfe_tls_cert_secret_arn`, `tfe_tls_privkey_secret_arn`, and any applicable secondary or CA bundle secrets). If you need assistance base64-encoding the files into strings prior to updating the secrets, see the examples below:
 
     On Linux (bash):
 
@@ -52,8 +56,12 @@ Follow these steps to rotate the certificates for your TFE instance.
     > When you update the value of an AWS Secrets Manager secret, the secret ARN should not change, so **no action should be needed** in terms of updating any input variable values. If the secret ARNs _were_ to change due to other circumstances, you would need to update the following input variable values with the new ARNs, and subsequently run `terraform apply` to update the TFE EC2 launch template:
     >
     >```hcl
-    >tfe_tls_cert_secret_arn    = "<new-tfe-tls-cert-secret-arn>"
-    >tfe_tls_privkey_secret_arn = "<new-tfe-tls-privkey-secret-arn>"
+    >tfe_tls_cert_secret_arn             = "<new-tfe-tls-cert-secret-arn>"
+    >tfe_tls_privkey_secret_arn          = "<new-tfe-tls-privkey-secret-arn>"
+    >tfe_tls_ca_bundle_secret_arn        = "<new-tfe-tls-ca-bundle-secret-arn>"
+    >tfe_tls_cert_secret_arn_secondary   = "<new-secondary-tfe-tls-cert-secret-arn>"
+    >tfe_tls_privkey_secret_arn_secondary = "<new-secondary-tfe-tls-privkey-secret-arn>"
+    >tfe_tls_ca_bundle_secret_arn_secondary = "<new-secondary-tfe-tls-ca-bundle-secret-arn>"
     >```
 
 1. During a maintenance window, terminate the running TFE EC2 instance(s) which will trigger the autoscaling group to spawn new instance(s) from the latest version of the TFE EC2 launch template. This process will effectively re-install TFE on the new instance(s), including the retrieval of the latest certificates from the AWS Secrets Manager secrets.

--- a/docs/tfe-config-settings.md
+++ b/docs/tfe-config-settings.md
@@ -14,6 +14,21 @@ Within the [compute.tf](../compute.tf) file, you will see a `locals` block with 
 
 Within the [tfe_user_data.sh](../templates/tfe_user_data.sh.tpl) script there is a function named `generate_tfe_docker_compose_config()` that is responsible for receiving all of those inputs and dynamically generating the `docker-compose.yaml` file. After a successful install process, this file can be found in `/etc/tfe/docker-compose.yaml` on your TFE EC2 instance(s).
 
+## Secondary hostname settings
+
+This module supports the documented secondary-hostname settings for Terraform Enterprise:
+
+- `TFE_HOSTNAME_SECONDARY`
+- `TFE_OIDC_HOSTNAME_CHOICE`
+- `TFE_VCS_HOSTNAME_CHOICE`
+- `TFE_RUN_TASK_HOSTNAME_CHOICE`
+- `TFE_TLS_CERT_FILE_SECONDARY`
+- `TFE_TLS_KEY_FILE_SECONDARY`
+
+The corresponding Terraform inputs are surfaced in [variables.tf](../variables.tf). The runtime values are assembled in [compute.tf](../compute.tf) and rendered into both the Docker Compose and Podman manifests by [tfe_user_data.sh](../templates/tfe_user_data.sh.tpl).
+
+When `tfe_hostname_secondary` is configured, the cloud-init script retrieves the secondary TLS materials from AWS Secrets Manager and writes them alongside the primary TLS files before starting Terraform Enterprise.
+
 ## Procedure
 
 1. Determine which [configuration setting](https://developer.hashicorp.com/terraform/enterprise/flexible-deployments/install/configuration) you would like to add/modify/update.

--- a/examples/main/variables.tf
+++ b/examples/main/variables.tf
@@ -49,6 +49,39 @@ variable "tfe_tls_ca_bundle_secret_arn" {
   description = "ARN of AWS Secrets Manager secret for private/custom TLS Certificate Authority (CA) bundle in PEM format. Secret must be stored as a base64-encoded string. Secret type should be plaintext."
 }
 
+variable "tfe_tls_cert_secret_arn_secondary" {
+  type        = string
+  description = "ARN of AWS Secrets Manager secret for the secondary TFE TLS certificate in PEM format. Secret must be stored as a base64-encoded string. Secret type should be plaintext."
+  default     = null
+
+  validation {
+    condition     = var.tfe_hostname_secondary != null ? var.tfe_tls_cert_secret_arn_secondary != null : var.tfe_tls_cert_secret_arn_secondary == null
+    error_message = "Value must be set when `tfe_hostname_secondary` is configured and must be `null` otherwise."
+  }
+}
+
+variable "tfe_tls_privkey_secret_arn_secondary" {
+  type        = string
+  description = "ARN of AWS Secrets Manager secret for the secondary TFE TLS private key in PEM format. Secret must be stored as a base64-encoded string. Secret type should be plaintext."
+  default     = null
+
+  validation {
+    condition     = var.tfe_hostname_secondary != null ? var.tfe_tls_privkey_secret_arn_secondary != null : var.tfe_tls_privkey_secret_arn_secondary == null
+    error_message = "Value must be set when `tfe_hostname_secondary` is configured and must be `null` otherwise."
+  }
+}
+
+variable "tfe_tls_ca_bundle_secret_arn_secondary" {
+  type        = string
+  description = "ARN of AWS Secrets Manager secret for the secondary TFE TLS certificate authority bundle in PEM format. Secret must be stored as a base64-encoded string. Secret type should be plaintext."
+  default     = null
+
+  validation {
+    condition     = var.tfe_hostname_secondary != null ? var.tfe_tls_ca_bundle_secret_arn_secondary != null : var.tfe_tls_ca_bundle_secret_arn_secondary == null
+    error_message = "Value must be set when `tfe_hostname_secondary` is configured and must be `null` otherwise."
+  }
+}
+
 variable "tfe_encryption_password_secret_arn" {
   type        = string
   description = "ARN of AWS Secrets Manager secret for TFE encryption password. Secret type should be plaintext."
@@ -115,6 +148,60 @@ variable "tfe_image_repository_password" {
 variable "tfe_fqdn" {
   type        = string
   description = "Fully qualified domain name (FQDN) of TFE instance. This name should resolve to the DNS name or IP address of the TFE load balancer and will be what clients use to access TFE."
+}
+
+variable "tfe_hostname_secondary" {
+  type        = string
+  description = "Secondary externally resolvable fully qualified domain name (FQDN) for TFE integration traffic such as OIDC, VCS, or run tasks."
+  default     = null
+}
+
+variable "tfe_oidc_hostname_choice" {
+  type        = string
+  description = "Hostname choice for TFE OIDC workload federation integrations. Supported values are `primary` and `secondary`."
+  default     = "primary"
+
+  validation {
+    condition     = contains(["primary", "secondary"], var.tfe_oidc_hostname_choice)
+    error_message = "Supported values are `primary` or `secondary`."
+  }
+
+  validation {
+    condition     = var.tfe_oidc_hostname_choice == "secondary" ? var.tfe_hostname_secondary != null : true
+    error_message = "`tfe_hostname_secondary` must be set when `tfe_oidc_hostname_choice` is `secondary`."
+  }
+}
+
+variable "tfe_vcs_hostname_choice" {
+  type        = string
+  description = "Hostname choice for TFE version control system (VCS) integrations. Supported values are `primary` and `secondary`."
+  default     = "primary"
+
+  validation {
+    condition     = contains(["primary", "secondary"], var.tfe_vcs_hostname_choice)
+    error_message = "Supported values are `primary` or `secondary`."
+  }
+
+  validation {
+    condition     = var.tfe_vcs_hostname_choice == "secondary" ? var.tfe_hostname_secondary != null : true
+    error_message = "`tfe_hostname_secondary` must be set when `tfe_vcs_hostname_choice` is `secondary`."
+  }
+}
+
+variable "tfe_run_task_hostname_choice" {
+  type        = string
+  description = "Hostname choice for TFE run task integrations. Supported values are `primary` and `secondary`."
+  default     = "primary"
+
+  validation {
+    condition     = contains(["primary", "secondary"], var.tfe_run_task_hostname_choice)
+    error_message = "Supported values are `primary` or `secondary`."
+  }
+
+  validation {
+    condition     = var.tfe_run_task_hostname_choice == "secondary" ? var.tfe_hostname_secondary != null : true
+    error_message = "`tfe_hostname_secondary` must be set when `tfe_run_task_hostname_choice` is `secondary`."
+  }
 }
 
 variable "tfe_capacity_concurrency" {
@@ -473,6 +560,67 @@ variable "route53_tfe_hosted_zone_is_private" {
   type        = bool
   description = "Boolean indicating if `route53_tfe_hosted_zone_name` is a private hosted zone."
   default     = false
+}
+
+variable "create_secondary_tfe_nlb" {
+  type        = bool
+  description = "Boolean to create a dedicated public Network Load Balancer (NLB) for `tfe_hostname_secondary`."
+  default     = false
+
+  validation {
+    condition     = var.create_secondary_tfe_nlb ? var.tfe_hostname_secondary != null : true
+    error_message = "`tfe_hostname_secondary` must be set when `create_secondary_tfe_nlb` is `true`."
+  }
+}
+
+variable "secondary_lb_subnet_ids" {
+  type        = list(string)
+  description = "List of public subnet IDs to use for the secondary Network Load Balancer (NLB). Required when `create_secondary_tfe_nlb` is `true`."
+  default     = null
+
+  validation {
+    condition     = var.create_secondary_tfe_nlb ? var.secondary_lb_subnet_ids != null : true
+    error_message = "Value must be set when `create_secondary_tfe_nlb` is `true`."
+  }
+}
+
+variable "cidr_allow_ingress_tfe_secondary_443" {
+  type        = list(string)
+  description = "List of CIDR ranges allowed to access the secondary TFE public Network Load Balancer (NLB) over HTTPS (port 443)."
+  default     = ["0.0.0.0/0"]
+}
+
+variable "create_route53_tfe_secondary_dns_record" {
+  type        = bool
+  description = "Boolean to create a Route53 Alias record for `tfe_hostname_secondary` resolving to the secondary public Network Load Balancer (NLB)."
+  default     = false
+
+  validation {
+    condition     = var.create_route53_tfe_secondary_dns_record ? var.create_secondary_tfe_nlb : true
+    error_message = "`create_secondary_tfe_nlb` must be `true` when `create_route53_tfe_secondary_dns_record` is `true`."
+  }
+}
+
+variable "route53_tfe_secondary_hosted_zone_name" {
+  type        = string
+  description = "Route53 Hosted Zone name to create the `tfe_hostname_secondary` alias record in. Required if `create_route53_tfe_secondary_dns_record` is `true`."
+  default     = null
+
+  validation {
+    condition     = var.create_route53_tfe_secondary_dns_record ? var.route53_tfe_secondary_hosted_zone_name != null : true
+    error_message = "Value must be set when `create_route53_tfe_secondary_dns_record` is `true`."
+  }
+}
+
+variable "route53_tfe_secondary_hosted_zone_is_private" {
+  type        = bool
+  description = "Boolean indicating if `route53_tfe_secondary_hosted_zone_name` is a private hosted zone. Secondary hostname DNS must be public when created by this module."
+  default     = false
+
+  validation {
+    condition     = var.create_route53_tfe_secondary_dns_record ? var.route53_tfe_secondary_hosted_zone_is_private == false : true
+    error_message = "`route53_tfe_secondary_hosted_zone_is_private` must be `false` when `create_route53_tfe_secondary_dns_record` is `true`."
+  }
 }
 
 #------------------------------------------------------------------------------

--- a/iam.tf
+++ b/iam.tf
@@ -159,6 +159,57 @@ data "aws_iam_policy_document" "tfe_ec2_get_tls_ca_bundle_secret" {
   }
 }
 
+data "aws_iam_policy_document" "tfe_ec2_get_tls_cert_secondary_secret" {
+  count = var.tfe_tls_cert_secret_arn_secondary != null ? 1 : 0
+
+  statement {
+    sid    = "TfeEc2GetTlsCertSecondarySecret"
+    effect = "Allow"
+
+    actions = [
+      "secretsmanager:GetSecretValue"
+    ]
+
+    resources = [
+      var.tfe_tls_cert_secret_arn_secondary
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "tfe_ec2_get_tls_privkey_secondary_secret" {
+  count = var.tfe_tls_privkey_secret_arn_secondary != null ? 1 : 0
+
+  statement {
+    sid    = "TfeEc2GetTlsPrivKeySecondarySecret"
+    effect = "Allow"
+
+    actions = [
+      "secretsmanager:GetSecretValue"
+    ]
+
+    resources = [
+      var.tfe_tls_privkey_secret_arn_secondary
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "tfe_ec2_get_tls_ca_bundle_secondary_secret" {
+  count = var.tfe_tls_ca_bundle_secret_arn_secondary != null ? 1 : 0
+
+  statement {
+    sid    = "TfeEc2GetTlsCaBundleSecondarySecret"
+    effect = "Allow"
+
+    actions = [
+      "secretsmanager:GetSecretValue"
+    ]
+
+    resources = [
+      var.tfe_tls_ca_bundle_secret_arn_secondary
+    ]
+  }
+}
+
 data "aws_iam_policy_document" "tfe_ec2_get_rds_password_secret" {
   count = var.tfe_database_password_secret_arn != null ? 1 : 0
 
@@ -352,6 +403,9 @@ data "aws_iam_policy_document" "tfe_ec2_combined" {
     var.tfe_tls_cert_secret_arn != null ? data.aws_iam_policy_document.tfe_ec2_get_tls_cert_secret[0].json : "",
     var.tfe_tls_privkey_secret_arn != null ? data.aws_iam_policy_document.tfe_ec2_get_tls_privkey_secret[0].json : "",
     var.tfe_tls_ca_bundle_secret_arn != null ? data.aws_iam_policy_document.tfe_ec2_get_tls_ca_bundle_secret[0].json : "",
+    var.tfe_tls_cert_secret_arn_secondary != null ? data.aws_iam_policy_document.tfe_ec2_get_tls_cert_secondary_secret[0].json : "",
+    var.tfe_tls_privkey_secret_arn_secondary != null ? data.aws_iam_policy_document.tfe_ec2_get_tls_privkey_secondary_secret[0].json : "",
+    var.tfe_tls_ca_bundle_secret_arn_secondary != null ? data.aws_iam_policy_document.tfe_ec2_get_tls_ca_bundle_secondary_secret[0].json : "",
     var.tfe_database_password_secret_arn != null ? data.aws_iam_policy_document.tfe_ec2_get_rds_password_secret[0].json : "",
     var.tfe_redis_password_secret_arn != null ? data.aws_iam_policy_document.tfe_ec2_allow_get_redis_password_secret[0].json : "",
     var.ebs_kms_key_arn != null ? data.aws_iam_policy_document.tfe_ec2_allow_ebs_kms_cmk[0].json : "",

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,9 +14,19 @@ output "tfe_create_initial_admin_user_url" {
   description = "URL to create TFE initial admin user."
 }
 
+output "tfe_secondary_url" {
+  value       = var.tfe_hostname_secondary == null ? null : "https://${var.tfe_hostname_secondary}"
+  description = "URL to access TFE external integrations based on value of `tfe_hostname_secondary` input."
+}
+
 output "lb_dns_name" {
   value       = var.lb_type == "alb" ? aws_lb.alb[0].dns_name : aws_lb.nlb[0].dns_name
   description = "DNS name of the Load Balancer."
+}
+
+output "secondary_lb_dns_name" {
+  value       = try(aws_lb.secondary_nlb[0].dns_name, null)
+  description = "DNS name of the secondary public Network Load Balancer (NLB)."
 }
 
 #------------------------------------------------------------------------------

--- a/s3.tf
+++ b/s3.tf
@@ -5,9 +5,9 @@
 # S3 bucket
 #------------------------------------------------------------------------------
 resource "aws_s3_bucket" "tfe" {
-  bucket = "${var.friendly_name_prefix}-tfe-app-${data.aws_region.current.name}-${data.aws_caller_identity.current.account_id}"
+  bucket        = "${var.friendly_name_prefix}-tfe-app-${data.aws_region.current.name}-${data.aws_caller_identity.current.account_id}"
   force_destroy = var.s3_force_destroy
-  
+
   tags = merge(
     { "Name" = "${var.friendly_name_prefix}-tfe-app-${data.aws_region.current.name}-${data.aws_caller_identity.current.account_id}" },
     var.common_tags

--- a/secondary.tf
+++ b/secondary.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 locals {
-  secondary_hostname_enabled = var.tfe_hostname_secondary != null
+  secondary_hostname_enabled = coalesce(var.tfe_hostname_secondary, "") != ""
   secondary_nlb_enabled      = local.secondary_hostname_enabled && var.create_secondary_tfe_nlb
   secondary_lb_target_group_arns = local.secondary_nlb_enabled ? [
     aws_lb_target_group.secondary_nlb_443[0].arn

--- a/secondary.tf
+++ b/secondary.tf
@@ -1,0 +1,164 @@
+# Copyright IBM Corp. 2024, 2025
+# SPDX-License-Identifier: MPL-2.0
+
+locals {
+  secondary_hostname_enabled = var.tfe_hostname_secondary != null
+  secondary_nlb_enabled      = local.secondary_hostname_enabled && var.create_secondary_tfe_nlb
+  secondary_lb_target_group_arns = local.secondary_nlb_enabled ? [
+    aws_lb_target_group.secondary_nlb_443[0].arn
+  ] : []
+}
+
+data "aws_route53_zone" "tfe_secondary" {
+  count = var.create_route53_tfe_secondary_dns_record && var.route53_tfe_secondary_hosted_zone_name != null ? 1 : 0
+
+  name         = var.route53_tfe_secondary_hosted_zone_name
+  private_zone = var.route53_tfe_secondary_hosted_zone_is_private
+}
+
+resource "aws_lb" "secondary_nlb" {
+  count = local.secondary_nlb_enabled ? 1 : 0
+
+  name               = "${var.friendly_name_prefix}-tfe2-nlb-public"
+  load_balancer_type = "network"
+  internal           = false
+  subnets            = var.secondary_lb_subnet_ids
+
+  security_groups = [
+    aws_security_group.secondary_lb_allow_ingress[0].id,
+    aws_security_group.secondary_lb_allow_egress[0].id
+  ]
+
+  tags = merge(
+    { "Name" = "${var.friendly_name_prefix}-tfe2-nlb-public" },
+    { "Description" = "Secondary public load balancer for Terraform Enterprise integration traffic." },
+    var.common_tags
+  )
+}
+
+resource "aws_lb_listener" "secondary_nlb_443" {
+  count = local.secondary_nlb_enabled ? 1 : 0
+
+  load_balancer_arn = aws_lb.secondary_nlb[0].arn
+  port              = 443
+  protocol          = "TCP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.secondary_nlb_443[0].arn
+  }
+}
+
+resource "aws_lb_target_group" "secondary_nlb_443" {
+  count = local.secondary_nlb_enabled ? 1 : 0
+
+  name     = "${var.friendly_name_prefix}-tfe2-nlb-tg443"
+  protocol = "TCP"
+  port     = 443
+  vpc_id   = var.vpc_id
+
+  health_check {
+    protocol            = "HTTPS"
+    path                = local.tfe_image_tag_gte_1 ? "/api/v1/health/readiness" : "/_health_check"
+    port                = "traffic-port"
+    matcher             = "200"
+    healthy_threshold   = 5
+    unhealthy_threshold = 5
+    timeout             = 10
+    interval            = 30
+  }
+
+  stickiness {
+    enabled = var.lb_stickiness_enabled
+    type    = "source_ip"
+  }
+
+  tags = merge(
+    { "Name" = "${var.friendly_name_prefix}-tfe2-nlb-tg443" },
+    { "Description" = "Load balancer target group for TFE secondary hostname traffic." },
+    var.common_tags
+  )
+}
+
+resource "aws_security_group" "secondary_lb_allow_ingress" {
+  count = local.secondary_nlb_enabled ? 1 : 0
+
+  name   = "${var.friendly_name_prefix}-tfe-secondary-lb-allow-ingress"
+  vpc_id = var.vpc_id
+
+  tags = merge({ "Name" = "${var.friendly_name_prefix}-tfe-secondary-lb-allow-ingress" }, var.common_tags)
+}
+
+resource "aws_security_group_rule" "secondary_lb_allow_ingress_tfe_https_from_cidr" {
+  count = local.secondary_nlb_enabled ? 1 : 0
+
+  type        = "ingress"
+  from_port   = 443
+  to_port     = 443
+  protocol    = "tcp"
+  cidr_blocks = var.cidr_allow_ingress_tfe_secondary_443
+  description = "Allow TCP/443 (HTTPS) inbound to the secondary TFE load balancer from specified CIDR ranges."
+
+  security_group_id = aws_security_group.secondary_lb_allow_ingress[0].id
+}
+
+resource "aws_security_group_rule" "secondary_lb_allow_ingress_tfe_https_from_ec2" {
+  count = local.secondary_nlb_enabled ? 1 : 0
+
+  type                     = "ingress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.ec2_allow_ingress.id
+  description              = "Allow TCP/443 (HTTPS) inbound to the secondary TFE load balancer from the TFE EC2 security group."
+
+  security_group_id = aws_security_group.secondary_lb_allow_ingress[0].id
+}
+
+resource "aws_security_group" "secondary_lb_allow_egress" {
+  count = local.secondary_nlb_enabled ? 1 : 0
+
+  name   = "${var.friendly_name_prefix}-tfe-secondary-lb-allow-egress"
+  vpc_id = var.vpc_id
+  tags   = merge({ "Name" = "${var.friendly_name_prefix}-tfe-secondary-lb-allow-egress" }, var.common_tags)
+}
+
+resource "aws_security_group_rule" "secondary_lb_allow_egress_all" {
+  count = local.secondary_nlb_enabled ? 1 : 0
+
+  type        = "egress"
+  from_port   = 0
+  to_port     = 0
+  protocol    = "-1"
+  cidr_blocks = ["0.0.0.0/0"]
+  description = "Allow all traffic outbound from the secondary TFE load balancer."
+
+  security_group_id = aws_security_group.secondary_lb_allow_egress[0].id
+}
+
+resource "aws_security_group_rule" "ec2_allow_ingress_tfe_https_from_secondary_lb" {
+  count = local.secondary_nlb_enabled ? 1 : 0
+
+  type                     = "ingress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.secondary_lb_allow_ingress[0].id
+  description              = "Allow TCP/443 (HTTPS) inbound to TFE EC2 instances from the secondary TFE load balancer."
+
+  security_group_id = aws_security_group.ec2_allow_ingress.id
+}
+
+resource "aws_route53_record" "secondary_alias_record" {
+  count = var.create_route53_tfe_secondary_dns_record ? 1 : 0
+
+  name    = var.tfe_hostname_secondary
+  zone_id = data.aws_route53_zone.tfe_secondary[0].zone_id
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.secondary_nlb[0].dns_name
+    zone_id                = aws_lb.secondary_nlb[0].zone_id
+    evaluate_target_health = true
+  }
+}

--- a/templates/tfe_user_data.sh.tpl
+++ b/templates/tfe_user_data.sh.tpl
@@ -466,10 +466,12 @@ spec:
       value: ${tfe_tls_cert_file}
     - name: "TFE_TLS_KEY_FILE"
       value: ${tfe_tls_key_file}
+%{ if tfe_hostname_secondary != "" ~}
     - name: "TFE_TLS_CERT_FILE_SECONDARY"
       value: ${tfe_tls_cert_file_secondary}
     - name: "TFE_TLS_KEY_FILE_SECONDARY"
       value: ${tfe_tls_key_file_secondary}
+%{ endif ~}
     - name: "TFE_TLS_CA_BUNDLE_FILE"
       value: ${tfe_tls_ca_bundle_file}
     - name: "TFE_TLS_CIPHERS"

--- a/templates/tfe_user_data.sh.tpl
+++ b/templates/tfe_user_data.sh.tpl
@@ -259,8 +259,19 @@ services:
       TFE_TLS_CERT_FILE: ${tfe_tls_cert_file}
       TFE_TLS_KEY_FILE: ${tfe_tls_key_file}
 %{ if tfe_hostname_secondary != "" ~}
+      TFE_HOSTNAME_SECONDARY: "${tfe_hostname_secondary}"
+      TFE_OIDC_HOSTNAME_CHOICE: "${tfe_oidc_hostname_choice}"
+      TFE_VCS_HOSTNAME_CHOICE: "${tfe_vcs_hostname_choice}"
+      TFE_RUN_TASK_HOSTNAME_CHOICE: "${tfe_run_task_hostname_choice}"
       TFE_TLS_CERT_FILE_SECONDARY: ${tfe_tls_cert_file_secondary}
       TFE_TLS_KEY_FILE_SECONDARY: ${tfe_tls_key_file_secondary}
+      TFE_TLS_CA_BUNDLE_FILE_SECONDARY: ${tfe_tls_ca_bundle_file_secondary}
+%{ else ~}
+      TFE_HOSTNAME_SECONDARY: ""
+	    TFE_OIDC_HOSTNAME_CHOICE: ""
+	    TFE_VCS_HOSTNAME_CHOICE: ""
+	    TFE_RUN_TASK_HOSTNAME_CHOICE: ""
+%{ endif ~}
 %{ endif ~}
       TFE_TLS_CA_BUNDLE_FILE: ${tfe_tls_ca_bundle_file}
       TFE_TLS_CIPHERS: ${tfe_tls_ciphers}
@@ -374,8 +385,10 @@ spec:
     # Application settings
     - name: "TFE_HOSTNAME"
       value: ${tfe_hostname}
+%{ if tfe_hostname_secondary != "" ~}
     - name: "TFE_HOSTNAME_SECONDARY"
       value: ${tfe_hostname_secondary}
+%{ endif ~}
     - name: "TFE_OIDC_HOSTNAME_CHOICE"
       value: ${tfe_oidc_hostname_choice}
     - name: "TFE_VCS_HOSTNAME_CHOICE"
@@ -467,10 +480,12 @@ spec:
     - name: "TFE_TLS_KEY_FILE"
       value: ${tfe_tls_key_file}
 %{ if tfe_hostname_secondary != "" ~}
-    - name: "TFE_TLS_CERT_FILE_SECONDARY"
-      value: ${tfe_tls_cert_file_secondary}
-    - name: "TFE_TLS_KEY_FILE_SECONDARY"
-      value: ${tfe_tls_key_file_secondary}
+	- name: "TFE_TLS_CERT_FILE_SECONDARY"
+		value: ${tfe_tls_cert_file_secondary}
+	- name: "TFE_TLS_KEY_FILE_SECONDARY"
+		value: ${tfe_tls_key_file_secondary}
+	- name: "TFE_TLS_CA_BUNDLE_FILE_SECONDARY"
+		value: ${tfe_tls_ca_bundle_file_secondary}
 %{ endif ~}
     - name: "TFE_TLS_CA_BUNDLE_FILE"
       value: ${tfe_tls_ca_bundle_file}

--- a/templates/tfe_user_data.sh.tpl
+++ b/templates/tfe_user_data.sh.tpl
@@ -205,6 +205,10 @@ services:
     environment:
       # Application settings
       TFE_HOSTNAME: ${tfe_hostname}
+      TFE_HOSTNAME_SECONDARY: ${tfe_hostname_secondary}
+      TFE_OIDC_HOSTNAME_CHOICE: ${tfe_oidc_hostname_choice}
+      TFE_VCS_HOSTNAME_CHOICE: ${tfe_vcs_hostname_choice}
+      TFE_RUN_TASK_HOSTNAME_CHOICE: ${tfe_run_task_hostname_choice}
       TFE_LICENSE: $TFE_LICENSE
       TFE_LICENSE_PATH: ""
       TFE_OPERATIONAL_MODE: ${tfe_operational_mode}
@@ -254,6 +258,8 @@ services:
       # TLS settings
       TFE_TLS_CERT_FILE: ${tfe_tls_cert_file}
       TFE_TLS_KEY_FILE: ${tfe_tls_key_file}
+      TFE_TLS_CERT_FILE_SECONDARY: ${tfe_tls_cert_file_secondary}
+      TFE_TLS_KEY_FILE_SECONDARY: ${tfe_tls_key_file_secondary}
       TFE_TLS_CA_BUNDLE_FILE: ${tfe_tls_ca_bundle_file}
       TFE_TLS_CIPHERS: ${tfe_tls_ciphers}
       TFE_TLS_ENFORCE: ${tfe_tls_enforce}
@@ -270,7 +276,10 @@ services:
       TFE_DISK_CACHE_PATH: /var/cache/tfe-task-worker
       TFE_DISK_CACHE_VOLUME_NAME: terraform-enterprise-cache
       TFE_RUN_PIPELINE_DOCKER_NETWORK: ${tfe_run_pipeline_docker_network}
-%{ if tfe_hairpin_addressing ~}
+%{ if tfe_hairpin_addressing && tfe_hostname_secondary != "" ~}
+      # Prevent loopback with Layer 4 load balancer with hairpinning TFE agent traffic
+      TFE_RUN_PIPELINE_DOCKER_EXTRA_HOSTS: ${tfe_hostname}:$VM_PRIVATE_IP,${tfe_hostname_secondary}:$VM_PRIVATE_IP
+%{ elseif tfe_hairpin_addressing ~}
       # Prevent loopback with Layer 4 load balancer with hairpinning TFE agent traffic
       TFE_RUN_PIPELINE_DOCKER_EXTRA_HOSTS: ${tfe_hostname}:$VM_PRIVATE_IP
 %{ endif ~}
@@ -293,6 +302,9 @@ services:
 %{ if tfe_hairpin_addressing ~}
     extra_hosts:
       - ${tfe_hostname}:$VM_PRIVATE_IP
+%{ if tfe_hostname_secondary != "" ~}
+      - ${tfe_hostname_secondary}:$VM_PRIVATE_IP
+%{ endif ~}
 %{ endif ~}
     cap_add:
       - IPC_LOCK
@@ -351,12 +363,23 @@ spec:
     - ip: $VM_PRIVATE_IP
       hostnames:
         - "${tfe_hostname}"
+%{ if tfe_hostname_secondary != "" ~}
+        - "${tfe_hostname_secondary}"
+%{ endif ~}
 %{ endif ~}
   containers:
   - env:
     # Application settings
     - name: "TFE_HOSTNAME"
       value: ${tfe_hostname}
+    - name: "TFE_HOSTNAME_SECONDARY"
+      value: ${tfe_hostname_secondary}
+    - name: "TFE_OIDC_HOSTNAME_CHOICE"
+      value: ${tfe_oidc_hostname_choice}
+    - name: "TFE_VCS_HOSTNAME_CHOICE"
+      value: ${tfe_vcs_hostname_choice}
+    - name: "TFE_RUN_TASK_HOSTNAME_CHOICE"
+      value: ${tfe_run_task_hostname_choice}
     - name: "TFE_LICENSE"
       value: $TFE_LICENSE
     - name: "TFE_LICENSE_PATH"
@@ -441,6 +464,10 @@ spec:
       value: ${tfe_tls_cert_file}
     - name: "TFE_TLS_KEY_FILE"
       value: ${tfe_tls_key_file}
+    - name: "TFE_TLS_CERT_FILE_SECONDARY"
+      value: ${tfe_tls_cert_file_secondary}
+    - name: "TFE_TLS_KEY_FILE_SECONDARY"
+      value: ${tfe_tls_key_file_secondary}
     - name: "TFE_TLS_CA_BUNDLE_FILE"
       value: ${tfe_tls_ca_bundle_file}
     - name: "TFE_TLS_CIPHERS"
@@ -463,7 +490,11 @@ spec:
       value: ${tfe_metrics_https_port}
 
     # Docker driver settings
-%{ if tfe_hairpin_addressing ~}
+%{ if tfe_hairpin_addressing && tfe_hostname_secondary != "" ~}
+      # Prevent loopback with Layer 4 load balancer with hairpinning TFE agent traffic
+    - name: "TFE_RUN_PIPELINE_DOCKER_EXTRA_HOSTS"
+      value: ${tfe_hostname}:$VM_PRIVATE_IP,${tfe_hostname_secondary}:$VM_PRIVATE_IP
+%{ elseif tfe_hairpin_addressing ~}
       # Prevent loopback with Layer 4 load balancer with hairpinning TFE agent traffic
     - name: "TFE_RUN_PIPELINE_DOCKER_EXTRA_HOSTS"
       value: ${tfe_hostname}:$VM_PRIVATE_IP
@@ -678,6 +709,16 @@ function main {
   retrieve_certs_from_awssm "${tfe_tls_privkey_secret_arn}" "$TFE_TLS_CERTS_DIR/key.pem"
   log "INFO" "Retrieving TFE TLS CA bundle..."
   retrieve_certs_from_awssm "${tfe_tls_ca_bundle_secret_arn}" "$TFE_TLS_CERTS_DIR/bundle.pem"
+  if [[ "${tfe_hostname_secondary}" != "" ]]; then
+    log "INFO" "Retrieving secondary TFE TLS certificate..."
+    retrieve_certs_from_awssm "${tfe_tls_cert_secret_arn_secondary}" "$TFE_TLS_CERTS_DIR/ext_cert.pem"
+    log "INFO" "Retrieving secondary TFE TLS private key..."
+    retrieve_certs_from_awssm "${tfe_tls_privkey_secret_arn_secondary}" "$TFE_TLS_CERTS_DIR/ext_key.pem"
+    log "INFO" "Retrieving secondary TFE TLS CA bundle..."
+    retrieve_certs_from_awssm "${tfe_tls_ca_bundle_secret_arn_secondary}" "$TFE_TLS_CERTS_DIR/bundle-secondary.pem"
+    printf '\n' >> "$TFE_TLS_CERTS_DIR/bundle.pem"
+    cat "$TFE_TLS_CERTS_DIR/bundle-secondary.pem" >> "$TFE_TLS_CERTS_DIR/bundle.pem"
+  fi
 
   log "INFO" "Retrieving 'TFE_ENCRYPTION_PASSWORD' secret from ${tfe_encryption_password_secret_arn}..."
   TFE_ENCRYPTION_PASSWORD=$(aws secretsmanager get-secret-value --region $AWS_REGION --secret-id "${tfe_encryption_password_secret_arn}" --query SecretString --output text)

--- a/templates/tfe_user_data.sh.tpl
+++ b/templates/tfe_user_data.sh.tpl
@@ -258,8 +258,10 @@ services:
       # TLS settings
       TFE_TLS_CERT_FILE: ${tfe_tls_cert_file}
       TFE_TLS_KEY_FILE: ${tfe_tls_key_file}
+%{ if tfe_hostname_secondary != "" ~}
       TFE_TLS_CERT_FILE_SECONDARY: ${tfe_tls_cert_file_secondary}
       TFE_TLS_KEY_FILE_SECONDARY: ${tfe_tls_key_file_secondary}
+%{ endif ~}
       TFE_TLS_CA_BUNDLE_FILE: ${tfe_tls_ca_bundle_file}
       TFE_TLS_CIPHERS: ${tfe_tls_ciphers}
       TFE_TLS_ENFORCE: ${tfe_tls_enforce}

--- a/variables.tf
+++ b/variables.tf
@@ -55,7 +55,7 @@ variable "tfe_tls_cert_secret_arn_secondary" {
   default     = null
 
   validation {
-    condition     = var.tfe_hostname_secondary != null ? var.tfe_tls_cert_secret_arn_secondary != null : var.tfe_tls_cert_secret_arn_secondary == null
+    condition     = var.tfe_hostname_secondary != null && var.tfe_hostname_secondary != "" ? var.tfe_tls_cert_secret_arn_secondary != null : var.tfe_tls_cert_secret_arn_secondary == null
     error_message = "Value must be set when `tfe_hostname_secondary` is configured and must be `null` otherwise."
   }
 }
@@ -66,7 +66,7 @@ variable "tfe_tls_privkey_secret_arn_secondary" {
   default     = null
 
   validation {
-    condition     = var.tfe_hostname_secondary != null ? var.tfe_tls_privkey_secret_arn_secondary != null : var.tfe_tls_privkey_secret_arn_secondary == null
+    condition     = var.tfe_hostname_secondary != null && var.tfe_hostname_secondary != "" ? var.tfe_tls_privkey_secret_arn_secondary != null : var.tfe_tls_privkey_secret_arn_secondary == null
     error_message = "Value must be set when `tfe_hostname_secondary` is configured and must be `null` otherwise."
   }
 }
@@ -77,7 +77,7 @@ variable "tfe_tls_ca_bundle_secret_arn_secondary" {
   default     = null
 
   validation {
-    condition     = var.tfe_hostname_secondary != null ? var.tfe_tls_ca_bundle_secret_arn_secondary != null : var.tfe_tls_ca_bundle_secret_arn_secondary == null
+    condition     = var.tfe_hostname_secondary != null && var.tfe_hostname_secondary != "" ? var.tfe_tls_ca_bundle_secret_arn_secondary != null : var.tfe_tls_ca_bundle_secret_arn_secondary == null
     error_message = "Value must be set when `tfe_hostname_secondary` is configured and must be `null` otherwise."
   }
 }
@@ -154,6 +154,15 @@ variable "tfe_hostname_secondary" {
   type        = string
   description = "Secondary externally resolvable fully qualified domain name (FQDN) for TFE integration traffic such as OIDC, VCS, or run tasks."
   default     = null
+
+  validation {
+    condition     = var.tfe_hostname_secondary == null || trim(var.tfe_hostname_secondary) != ""
+    error_message = "`tfe_hostname_secondary` must be either null or a non-empty string."
+  }
+}
+		condition = var.tfe_hostname_secondary is null || var.tfe_hostname_secondary != ""
+		error_message = "Secondary hostname must be a non-empty string if specified."
+	}
 }
 
 variable "tfe_oidc_hostname_choice" {
@@ -162,10 +171,10 @@ variable "tfe_oidc_hostname_choice" {
   default     = "primary"
 
   validation {
-    condition     = contains(["primary", "secondary"], var.tfe_oidc_hostname_choice)
-    error_message = "Supported values are `primary` or `secondary`."
+  validation {
+    condition     = var.tfe_oidc_hostname_choice == "secondary" ? var.tfe_hostname_secondary != null && var.tfe_hostname_secondary != "" : true
+    error_message = "`tfe_hostname_secondary` must be set when `tfe_oidc_hostname_choice` is `secondary`."
   }
-
   validation {
     condition     = var.tfe_oidc_hostname_choice == "secondary" ? var.tfe_hostname_secondary != null : true
     error_message = "`tfe_hostname_secondary` must be set when `tfe_oidc_hostname_choice` is `secondary`."
@@ -178,10 +187,10 @@ variable "tfe_vcs_hostname_choice" {
   default     = "primary"
 
   validation {
-    condition     = contains(["primary", "secondary"], var.tfe_vcs_hostname_choice)
-    error_message = "Supported values are `primary` or `secondary`."
+  validation {
+    condition     = var.tfe_vcs_hostname_choice == "secondary" ? var.tfe_hostname_secondary != null && var.tfe_hostname_secondary != "" : true
+    error_message = "`tfe_hostname_secondary` must be set when `tfe_vcs_hostname_choice` is `secondary`."
   }
-
   validation {
     condition     = var.tfe_vcs_hostname_choice == "secondary" ? var.tfe_hostname_secondary != null : true
     error_message = "`tfe_hostname_secondary` must be set when `tfe_vcs_hostname_choice` is `secondary`."
@@ -194,10 +203,10 @@ variable "tfe_run_task_hostname_choice" {
   default     = "primary"
 
   validation {
-    condition     = contains(["primary", "secondary"], var.tfe_run_task_hostname_choice)
-    error_message = "Supported values are `primary` or `secondary`."
+  validation {
+    condition     = var.tfe_run_task_hostname_choice == "secondary" ? var.tfe_hostname_secondary != null && var.tfe_hostname_secondary != "" : true
+    error_message = "`tfe_hostname_secondary` must be set when `tfe_run_task_hostname_choice` is `secondary`."
   }
-
   validation {
     condition     = var.tfe_run_task_hostname_choice == "secondary" ? var.tfe_hostname_secondary != null : true
     error_message = "`tfe_hostname_secondary` must be set when `tfe_run_task_hostname_choice` is `secondary`."
@@ -563,10 +572,10 @@ variable "route53_tfe_hosted_zone_is_private" {
 }
 
 variable "create_secondary_tfe_nlb" {
-  type        = bool
-  description = "Boolean to create a dedicated public Network Load Balancer (NLB) for `tfe_hostname_secondary`."
-  default     = false
-
+  validation {
+    condition     = var.create_secondary_tfe_nlb ? var.tfe_hostname_secondary != null && var.tfe_hostname_secondary != "" : true
+    error_message = "`tfe_hostname_secondary` must be set when `create_secondary_tfe_nlb` is `true`."
+  }
   validation {
     condition     = var.create_secondary_tfe_nlb ? var.tfe_hostname_secondary != null : true
     error_message = "`tfe_hostname_secondary` must be set when `create_secondary_tfe_nlb` is `true`."

--- a/variables.tf
+++ b/variables.tf
@@ -49,6 +49,39 @@ variable "tfe_tls_ca_bundle_secret_arn" {
   description = "ARN of AWS Secrets Manager secret for private/custom TLS Certificate Authority (CA) bundle in PEM format. Secret must be stored as a base64-encoded string. Secret type should be plaintext."
 }
 
+variable "tfe_tls_cert_secret_arn_secondary" {
+  type        = string
+  description = "ARN of AWS Secrets Manager secret for the secondary TFE TLS certificate in PEM format. Secret must be stored as a base64-encoded string. Secret type should be plaintext."
+  default     = null
+
+  validation {
+    condition     = var.tfe_hostname_secondary != null ? var.tfe_tls_cert_secret_arn_secondary != null : var.tfe_tls_cert_secret_arn_secondary == null
+    error_message = "Value must be set when `tfe_hostname_secondary` is configured and must be `null` otherwise."
+  }
+}
+
+variable "tfe_tls_privkey_secret_arn_secondary" {
+  type        = string
+  description = "ARN of AWS Secrets Manager secret for the secondary TFE TLS private key in PEM format. Secret must be stored as a base64-encoded string. Secret type should be plaintext."
+  default     = null
+
+  validation {
+    condition     = var.tfe_hostname_secondary != null ? var.tfe_tls_privkey_secret_arn_secondary != null : var.tfe_tls_privkey_secret_arn_secondary == null
+    error_message = "Value must be set when `tfe_hostname_secondary` is configured and must be `null` otherwise."
+  }
+}
+
+variable "tfe_tls_ca_bundle_secret_arn_secondary" {
+  type        = string
+  description = "ARN of AWS Secrets Manager secret for the secondary TFE TLS certificate authority bundle in PEM format. Secret must be stored as a base64-encoded string. Secret type should be plaintext."
+  default     = null
+
+  validation {
+    condition     = var.tfe_hostname_secondary != null ? var.tfe_tls_ca_bundle_secret_arn_secondary != null : var.tfe_tls_ca_bundle_secret_arn_secondary == null
+    error_message = "Value must be set when `tfe_hostname_secondary` is configured and must be `null` otherwise."
+  }
+}
+
 variable "tfe_encryption_password_secret_arn" {
   type        = string
   description = "ARN of AWS Secrets Manager secret for TFE encryption password. Secret type should be plaintext."
@@ -115,6 +148,60 @@ variable "tfe_image_repository_password" {
 variable "tfe_fqdn" {
   type        = string
   description = "Fully qualified domain name (FQDN) of TFE instance. This name should resolve to the DNS name or IP address of the TFE load balancer and will be what clients use to access TFE."
+}
+
+variable "tfe_hostname_secondary" {
+  type        = string
+  description = "Secondary externally resolvable fully qualified domain name (FQDN) for TFE integration traffic such as OIDC, VCS, or run tasks."
+  default     = null
+}
+
+variable "tfe_oidc_hostname_choice" {
+  type        = string
+  description = "Hostname choice for TFE OIDC workload federation integrations. Supported values are `primary` and `secondary`."
+  default     = "primary"
+
+  validation {
+    condition     = contains(["primary", "secondary"], var.tfe_oidc_hostname_choice)
+    error_message = "Supported values are `primary` or `secondary`."
+  }
+
+  validation {
+    condition     = var.tfe_oidc_hostname_choice == "secondary" ? var.tfe_hostname_secondary != null : true
+    error_message = "`tfe_hostname_secondary` must be set when `tfe_oidc_hostname_choice` is `secondary`."
+  }
+}
+
+variable "tfe_vcs_hostname_choice" {
+  type        = string
+  description = "Hostname choice for TFE version control system (VCS) integrations. Supported values are `primary` and `secondary`."
+  default     = "primary"
+
+  validation {
+    condition     = contains(["primary", "secondary"], var.tfe_vcs_hostname_choice)
+    error_message = "Supported values are `primary` or `secondary`."
+  }
+
+  validation {
+    condition     = var.tfe_vcs_hostname_choice == "secondary" ? var.tfe_hostname_secondary != null : true
+    error_message = "`tfe_hostname_secondary` must be set when `tfe_vcs_hostname_choice` is `secondary`."
+  }
+}
+
+variable "tfe_run_task_hostname_choice" {
+  type        = string
+  description = "Hostname choice for TFE run task integrations. Supported values are `primary` and `secondary`."
+  default     = "primary"
+
+  validation {
+    condition     = contains(["primary", "secondary"], var.tfe_run_task_hostname_choice)
+    error_message = "Supported values are `primary` or `secondary`."
+  }
+
+  validation {
+    condition     = var.tfe_run_task_hostname_choice == "secondary" ? var.tfe_hostname_secondary != null : true
+    error_message = "`tfe_hostname_secondary` must be set when `tfe_run_task_hostname_choice` is `secondary`."
+  }
 }
 
 variable "tfe_capacity_concurrency" {
@@ -473,6 +560,67 @@ variable "route53_tfe_hosted_zone_is_private" {
   type        = bool
   description = "Boolean indicating if `route53_tfe_hosted_zone_name` is a private hosted zone."
   default     = false
+}
+
+variable "create_secondary_tfe_nlb" {
+  type        = bool
+  description = "Boolean to create a dedicated public Network Load Balancer (NLB) for `tfe_hostname_secondary`."
+  default     = false
+
+  validation {
+    condition     = var.create_secondary_tfe_nlb ? var.tfe_hostname_secondary != null : true
+    error_message = "`tfe_hostname_secondary` must be set when `create_secondary_tfe_nlb` is `true`."
+  }
+}
+
+variable "secondary_lb_subnet_ids" {
+  type        = list(string)
+  description = "List of public subnet IDs to use for the secondary Network Load Balancer (NLB). Required when `create_secondary_tfe_nlb` is `true`."
+  default     = null
+
+  validation {
+    condition     = var.create_secondary_tfe_nlb ? var.secondary_lb_subnet_ids != null : true
+    error_message = "Value must be set when `create_secondary_tfe_nlb` is `true`."
+  }
+}
+
+variable "cidr_allow_ingress_tfe_secondary_443" {
+  type        = list(string)
+  description = "List of CIDR ranges allowed to access the secondary TFE public Network Load Balancer (NLB) over HTTPS (port 443)."
+  default     = ["0.0.0.0/0"]
+}
+
+variable "create_route53_tfe_secondary_dns_record" {
+  type        = bool
+  description = "Boolean to create a Route53 Alias record for `tfe_hostname_secondary` resolving to the secondary public Network Load Balancer (NLB)."
+  default     = false
+
+  validation {
+    condition     = var.create_route53_tfe_secondary_dns_record ? var.create_secondary_tfe_nlb : true
+    error_message = "`create_secondary_tfe_nlb` must be `true` when `create_route53_tfe_secondary_dns_record` is `true`."
+  }
+}
+
+variable "route53_tfe_secondary_hosted_zone_name" {
+  type        = string
+  description = "Route53 Hosted Zone name to create the `tfe_hostname_secondary` alias record in. Required if `create_route53_tfe_secondary_dns_record` is `true`."
+  default     = null
+
+  validation {
+    condition     = var.create_route53_tfe_secondary_dns_record ? var.route53_tfe_secondary_hosted_zone_name != null : true
+    error_message = "Value must be set when `create_route53_tfe_secondary_dns_record` is `true`."
+  }
+}
+
+variable "route53_tfe_secondary_hosted_zone_is_private" {
+  type        = bool
+  description = "Boolean indicating if `route53_tfe_secondary_hosted_zone_name` is a private hosted zone. Secondary hostname DNS must be public when created by this module."
+  default     = false
+
+  validation {
+    condition     = var.create_route53_tfe_secondary_dns_record ? var.route53_tfe_secondary_hosted_zone_is_private == false : true
+    error_message = "`route53_tfe_secondary_hosted_zone_is_private` must be `false` when `create_route53_tfe_secondary_dns_record` is `true`."
+  }
 }
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
## Description
This PR adds optional secondary-hostname support for Terraform Enterprise external integrations, following the HashiCorp guidance for `TFE_HOSTNAME_SECONDARY`, hostname-choice settings, and secondary TLS files.

The module now:
- exposes secondary hostname inputs plus `TFE_OIDC_HOSTNAME_CHOICE`, `TFE_VCS_HOSTNAME_CHOICE`, and `TFE_RUN_TASK_HOSTNAME_CHOICE`
- retrieves secondary TLS certificate, key, and CA bundle materials from AWS Secrets Manager and wires the secondary cert/key into the TFE runtime
- optionally creates a dedicated public secondary NLB with its own CIDR filtering and Route53 alias record in `secondary.tf`
- attaches the autoscaling group to the secondary target group without changing the existing primary hostname path
- updates README and `/docs` guidance for prerequisites, bootstrap secrets, certificate rotation, deployment customization, and runtime configuration

## Related issue
N/A

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] This change requires a documentation update

## How has this been tested?
- Ran `terraform-docs .` to refresh the generated README inputs/outputs section
- Ran `task test`
- Confirmed the module validates for both the root module and `examples/main`

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional notes
- The managed secondary endpoint is intentionally modeled as a dedicated public NLB because external integrations require a publicly resolvable hostname.
- Secondary DNS management remains optional. Operators can set `tfe_hostname_secondary` and manage the external DNS / load balancer path outside the module if preferred.
- Secondary TLS CA bundle content is appended to the primary CA bundle during bootstrap so the trust bundle covers both hostname paths.
