### PR TITLE
Fix is_hash logic to exclude hashtags from semver tags

### DIFF
--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -16,10 +16,10 @@ locals {
   # Accept semver-ish tags like 1.3, 1.3.2, v1.3, v1.3.2
   normalized_tag = trimprefix(var.tfe_image_tag, "v")
   is_semver_tag  = can(regex("^[0-9]+\\.[0-9]+(\\.[0-9]+)?$", local.normalized_tag))
-
-  major = local.is_semver_tag ? tonumber(split(".", local.normalized_tag)[0]) : 0
-  minor = local.is_semver_tag ? tonumber(split(".", local.normalized_tag)[1]) : 0
-  patch = local.is_semver_tag ? tonumber(split(".", local.normalized_tag)[2]) : 0
+  is_commit_hash = can(regex("^[0-9a-f]{7,}$", var.tfe_image_tag))
+  major          = local.is_semver_tag ? tonumber(split(".", local.normalized_tag)[0]) : 0
+  minor          = local.is_semver_tag ? tonumber(split(".", local.normalized_tag)[1]) : 0
+  patch          = local.is_semver_tag ? tonumber(split(".", local.normalized_tag)[2]) : 0
 
   tfe_image_tag_gte_1 = (
     !local.is_calver_tag &&

--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -17,14 +17,15 @@ locals {
   normalized_tag = trimprefix(var.tfe_image_tag, "v")
   is_semver_tag  = can(regex("^[0-9]+\\.[0-9]+(\\.[0-9]+)?$", local.normalized_tag))
   is_commit_hash = can(regex("^[0-9a-f]{7,}$", var.tfe_image_tag))
-  major          = local.is_semver_tag ? tonumber(split(".", local.normalized_tag)[0]) : 0
-  minor          = local.is_semver_tag ? tonumber(split(".", local.normalized_tag)[1]) : 0
-  patch          = local.is_semver_tag ? tonumber(split(".", local.normalized_tag)[2]) : 0
+
+  major = local.is_semver_tag ? tonumber(split(".", local.normalized_tag)[0]) : 0
+  minor = local.is_semver_tag ? tonumber(split(".", local.normalized_tag)[1]) : 0
+  patch = local.is_semver_tag ? tonumber(split(".", local.normalized_tag)[2]) : 0
 
   tfe_image_tag_gte_1 = (
     !local.is_calver_tag &&
     local.is_semver_tag &&
-    (local.major > 1 || (local.major == 1 && local.minor >= 2 && local.patch >= 1))
+    (local.is_commit_hash || local.major > 1 || (local.major == 1 && local.minor >= 2 && local.patch >= 1))
   )
 }
 

--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -20,12 +20,20 @@ locals {
 
   major = local.is_semver_tag ? tonumber(split(".", local.normalized_tag)[0]) : 0
   minor = local.is_semver_tag ? tonumber(split(".", local.normalized_tag)[1]) : 0
-  patch = local.is_semver_tag ? tonumber(split(".", local.normalized_tag)[2]) : 0
+  patch = local.is_semver_tag && length(split(".", local.normalized_tag)) > 2 ? tonumber(split(".", local.normalized_tag)[2]) : 0
 
   tfe_image_tag_gte_1 = (
     !local.is_calver_tag &&
-    local.is_semver_tag &&
-    (local.is_commit_hash || local.major > 1 || (local.major == 1 && local.minor >= 2 && local.patch >= 1))
+    (
+      local.is_commit_hash ||
+      (
+        local.is_semver_tag &&
+        (
+          local.major > 1 ||
+          (local.major == 1 && local.minor >= 2)
+        )
+      )
+    )
   )
 }
 


### PR DESCRIPTION
This pull request updates the logic in the `locals` block of `load_balancer.tf` to improve how image tags are parsed and evaluated. The changes enhance support for commit hash tags, improve patch version handling, and adjust the criteria for the `tfe_image_tag_gte_1` flag.

Tag parsing and evaluation improvements:

* Added support for detecting commit hash tags by introducing the `is_commit_hash` local, which checks if the image tag matches a 7+ character hexadecimal string.
* Improved patch version extraction by ensuring the patch number is only parsed if a third version segment exists in the tag.
* Updated the logic for the `tfe_image_tag_gte_1` flag to include commit hash tags and to refine the version comparison for semantic version tags, now considering `major > 1` or `major == 1 && minor >= 2`.## Description
[Provide a brief description of the changes in this PR]

## Related issue
NA

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How has this been tested?
- [Describe the tests you ran to verify your changes]
- [Provide any results or outcomes from the tests]
- [Include any additional notes related to the tests]

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional notes
[Add any additional information or context about the PR here]
