### PR TITLE
add RHEL 10 as an ec2_os_distro value

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,20 +193,20 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.100 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.100 |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_autoscaling_group.tfe](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
 | [aws_db_parameter_group.tfe](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_parameter_group) | resource |
 | [aws_db_subnet_group.tfe](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_subnet_group) | resource |
@@ -300,7 +300,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_ec2_subnet_ids"></a> [ec2\_subnet\_ids](#input\_ec2\_subnet\_ids) | List of subnet IDs to use for the EC2 instance. Private subnets is the best practice here. | `list(string)` | n/a | yes |
 | <a name="input_friendly_name_prefix"></a> [friendly\_name\_prefix](#input\_friendly\_name\_prefix) | Friendly name prefix used for uniquely naming all AWS resources for this deployment. Most commonly set to either an environment (e.g. 'sandbox', 'prod'), a team name, or a project name. | `string` | n/a | yes |
 | <a name="input_lb_subnet_ids"></a> [lb\_subnet\_ids](#input\_lb\_subnet\_ids) | List of subnet IDs to use for the load balancer. If `lb_is_internal` is `false`, then these should be public subnets. Otherwise, these should be private subnets. | `list(string)` | n/a | yes |
@@ -342,7 +342,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | <a name="input_ec2_allow_ssm"></a> [ec2\_allow\_ssm](#input\_ec2\_allow\_ssm) | Boolean to attach the `AmazonSSMManagedInstanceCore` policy to the TFE instance role, allowing the SSM agent (if present) to function. | `bool` | `false` | no |
 | <a name="input_ec2_ami_id"></a> [ec2\_ami\_id](#input\_ec2\_ami\_id) | Custom AMI ID for TFE EC2 launch template. If specified, value of `ec2_os_distro` must coincide with this custom AMI OS distro. | `string` | `null` | no |
 | <a name="input_ec2_instance_size"></a> [ec2\_instance\_size](#input\_ec2\_instance\_size) | EC2 instance type for TFE EC2 launch template. | `string` | `"m7i.xlarge"` | no |
-| <a name="input_ec2_os_distro"></a> [ec2\_os\_distro](#input\_ec2\_os\_distro) | Linux OS distribution type for TFE EC2 instance. Choose from `al2023`, `ubuntu`, `rhel`, `centos`. | `string` | `"ubuntu"` | no |
+| <a name="input_ec2_os_distro"></a> [ec2\_os\_distro](#input\_ec2\_os\_distro) | Linux OS distribution type for TFE EC2 instance. Choose from `al2023`, `ubuntu`, `rhel` (RHEL9), `rhel10` (RHEL 10), `centos`. | `string` | `"ubuntu"` | no |
 | <a name="input_ec2_ssh_key_pair"></a> [ec2\_ssh\_key\_pair](#input\_ec2\_ssh\_key\_pair) | Name of existing SSH key pair to attach to TFE EC2 instance. | `string` | `null` | no |
 | <a name="input_http_proxy"></a> [http\_proxy](#input\_http\_proxy) | Proxy address (including port number) for TFE to use for outbound HTTP requests (e.g. `http://proxy.example.com:3128`). | `string` | `null` | no |
 | <a name="input_https_proxy"></a> [https\_proxy](#input\_https\_proxy) | Proxy address (including port number) for TFE to use for outbound HTTPS requests (e.g. `http://proxy.example.com:3128`). | `string` | `null` | no |
@@ -434,7 +434,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_elasticache_replication_group_arn"></a> [elasticache\_replication\_group\_arn](#output\_elasticache\_replication\_group\_arn) | ARN of ElastiCache Replication Group (Redis) cluster. |
 | <a name="output_elasticache_replication_group_id"></a> [elasticache\_replication\_group\_id](#output\_elasticache\_replication\_group\_id) | ID of ElastiCache Replication Group (Redis) cluster. |
 | <a name="output_elasticache_replication_group_primary_endpoint_address"></a> [elasticache\_replication\_group\_primary\_endpoint\_address](#output\_elasticache\_replication\_group\_primary\_endpoint\_address) | Primary endpoint address of ElastiCache Replication Group (Redis) cluster. |

--- a/data.tf
+++ b/data.tf
@@ -45,14 +45,14 @@ data "aws_ami" "ubuntu" {
 }
 
 data "aws_ami" "rhel" {
-  count = var.ec2_os_distro == "rhel" && var.ec2_ami_id == null ? 1 : 0
+  count = (var.ec2_os_distro == "rhel" || var.ec2_os_distro == "rhel10") && var.ec2_ami_id == null ? 1 : 0
 
   owners      = ["309956199498"]
   most_recent = true
 
   filter {
     name   = "name"
-    values = ["RHEL-9.*_HVM-*-x86_64-*-Hourly2-GP3"]
+    values = [var.ec2_os_distro == "rhel10" ? "RHEL-10.*_HVM-*-x86_64-*-Hourly2-GP3" : "RHEL-9.*_HVM-*-x86_64-*-Hourly2-GP3"]
   }
 
   filter {

--- a/docs/deployment-customizations.md
+++ b/docs/deployment-customizations.md
@@ -77,14 +77,16 @@ By default, the [tfe_user_data](../templates/tfe_user_data.sh.tpl) (cloud-init) 
 - `aws-cli` - used to fetch the required bootstrap secrets from AWS Secrets Manager
 - `docker` or `podman` (depending on the value of the `container_runtime` input) - used to run the TFE application
 
+> **Note:** RHEL 10 does not officially support Docker. When using `ec2_os_distro = "rhel10"`, `podman` is the supported container runtime. To use Docker on RHEL 10, provide a custom AMI with Docker pre-installed via `ec2_ami_id` and set `container_runtime = "docker"`.
+
 If your TFE environment lacks egress connectivity to the official Linux package repositories, you should bake those dependencies into a custom image before deploying TFE. See the [Custom AMI](#custom-ami) section below for details.
 
 ## Custom AMI
 
-By default, this module uses the standard AWS Marketplace image based on the value of the `ec2_os_distro` input (either `ubuntu`, `rhel`, or `al2023`). If you prefer to override this behavior and use a custom AMI, set the `ec2_ami_id` input accordingly:
+By default, this module uses the standard AWS Marketplace image based on the value of the `ec2_os_distro` input (either `ubuntu`, `rhel`, `rhel10`, or `al2023`). If you prefer to override this behavior and use a custom AMI, set the `ec2_ami_id` input accordingly:
 
 ```hcl
-ec2_os_distro = "<os-distro>" # either 'ubuntu', 'rhel', 'al2023', or 'centos'
+ec2_os_distro = "<os-distro>" # either 'ubuntu', 'rhel' (RHEL 9), 'rhel10' (RHEL 10), 'al2023', or 'centos'
 ec2_ami_id    = "<custom-ami-id>"
 ```
 

--- a/examples/main/terraform.tfvars.example
+++ b/examples/main/terraform.tfvars.example
@@ -43,7 +43,7 @@ route53_tfe_hosted_zone_is_private = <true> # must be `true` when `lb_is_interna
 
 # --- Compute --- #
 container_runtime  = "docker"                 # either `docker` or `podman`
-ec2_os_distro      = "ubuntu"                 # either `ubuntu`, `rhel`, `al2023`, or `centos`
+ec2_os_distro      = "ubuntu"                 # either `ubuntu`, `rhel` (RHEL9), `rhel10` (RHEL10), `al2023`, or `centos`
 ec2_ssh_key_pair   = "<my-ec2-key-pair-name>" # set to `null` or remove if you do not want to use SSH for shell access
 ec2_allow_ssm      = false                    # set to `true` if you want to use SSM Session Manager for shell access
 ec2_instance_size  = "m7i.xlarge"
@@ -69,7 +69,7 @@ redis_multi_az_enabled           = true # requires more than one subnet specifie
 redis_automatic_failover_enabled = true # requires more than one subnet specified in `redis_subnet_ids` when `true`
 
 # --- Log forwarding (optional) --- #
-tfe_log_forwarding_enabled = <true>                      # set to `false` if you have your own 
+tfe_log_forwarding_enabled = <true>                      # set to `false` if you have your own
 log_fwd_destination_type   = "<s3>"                      # either `s3` or `cloudwatch`
 s3_log_fwd_bucket_name     = "<tfe-logging-bucket-name>" # set to `null` or remove when `log_fwd_destination_type` is `cloudwatch`
 #cloudwatch_log_group_name = "<tfe-log-group-name>"      # set to `null` or remove when `log_fwd_destination_type` is `s3`

--- a/examples/main/variables.tf
+++ b/examples/main/variables.tf
@@ -491,12 +491,12 @@ variable "container_runtime" {
 
 variable "ec2_os_distro" {
   type        = string
-  description = "Linux OS distribution type for TFE EC2 instance. Choose from `al2023`, `ubuntu`, `rhel`, `centos`."
+  description = "Linux OS distribution type for TFE EC2 instance. Choose from `al2023`, `ubuntu`, `rhel` (RHEL9), `rhel10` (RHEL 10), `centos`."
   default     = "ubuntu"
 
   validation {
-    condition     = contains(["ubuntu", "rhel", "al2023", "centos"], var.ec2_os_distro)
-    error_message = "Valid values are `ubuntu`, `rhel`, `al2023`, or `centos`."
+    condition     = contains(["ubuntu", "rhel", "rhel10", "al2023", "centos"], var.ec2_os_distro)
+    error_message = "Valid values are `ubuntu`, `rhel`, `rhel10`, `al2023`, or `centos`."
   }
 
   validation {

--- a/templates/tfe_user_data.sh.tpl
+++ b/templates/tfe_user_data.sh.tpl
@@ -29,7 +29,12 @@ function detect_os_distro {
       OS_DISTRO_DETECTED="centos"
       ;;
     "Red Hat"*)
-      OS_DISTRO_DETECTED="rhel"
+      local RHEL_VERSION_ID=$(grep "^VERSION_ID=" /etc/os-release | cut -d"\"" -f2 | cut -d"." -f1)
+      if [[ "$RHEL_VERSION_ID" == "10" ]]; then
+        OS_DISTRO_DETECTED="rhel10"
+      else
+        OS_DISTRO_DETECTED="rhel"
+      fi
       ;;
     "Amazon Linux"*)
       OS_DISTRO_DETECTED="al2023"
@@ -60,7 +65,7 @@ function install_awscli {
       if [[ "$OS_DISTRO" == "ubuntu" || "$OS_DISTRO" == "debian" ]]; then
         apt-get update -y
         apt-get install unzip -y
-      elif [[ "$OS_DISTRO" == "centos" || "$OS_DISTRO" == "rhel" || "$OS_DISTRO" == "al2023" ]]; then
+      elif [[ "$OS_DISTRO" == "centos" || "$OS_DISTRO" == rhel* || "$OS_DISTRO" == "al2023" ]]; then
         yum install unzip -y
       else
         log "ERROR" "Unable to install required 'unzip' utility. Exiting."
@@ -90,6 +95,9 @@ function install_docker {
       apt-get update -y
       DOCKER_VERSION="5:${docker_version}-1~ubuntu.$(lsb_release -r | awk '{print $2}')~$(lsb_release -cs)"
       apt-get install -y docker-ce="$${DOCKER_VERSION}" docker-ce-cli=$${DOCKER_VERSION} containerd.io docker-compose-plugin
+    elif [[ "$OS_DISTRO" == "rhel10" ]]; then
+      log "ERROR" "Docker is not officially supported on RHEL 10. Please use podman or provide a custom AMI with Docker pre-installed."
+      exit_script 6
     elif [[ "$OS_DISTRO" == "rhel" || "$OS_DISTRO" == "centos" ]]; then
       # https://docs.docker.com/engine/install/rhel/ or https://docs.docker.com/engine/install/centos/
       log "Warning" "Docker is no longer supported on RHEL 8 and beyond. Installing Docker CE..."
@@ -125,13 +133,13 @@ function install_podman {
   local OS_DISTRO="$1"
   local OS_MAJOR_VERSION="$2"
 
-  if command -v podman > /dev/null; then
-    log "INFO" "Detected 'podman' is already installed. Skipping."
+  if command -v podman > /dev/null && [[ -S /var/run/docker.sock ]]; then
+    log "INFO" "Detected 'podman' is already installed and docker.sock exists. Skipping."
   else
-    if [[ "$OS_DISTRO" == "rhel" || "$OS_DISTRO" == "centos" ]]; then
+    if [[ "$OS_DISTRO" == rhel* || "$OS_DISTRO" == "centos" ]]; then
       log "INFO" "Installing Podman for RHEL $OS_MAJOR_VERSION."
       dnf update -y
-      if [[ "$OS_MAJOR_VERSION" == "9" ]]; then
+      if [[ "$OS_MAJOR_VERSION" == "9" || "$OS_MAJOR_VERSION" == "10" ]]; then
         dnf install -y container-tools
       elif [[ "$OS_MAJOR_VERSION" == "8" ]]; then
         dnf module install -y container-tools

--- a/variables.tf
+++ b/variables.tf
@@ -491,12 +491,12 @@ variable "container_runtime" {
 
 variable "ec2_os_distro" {
   type        = string
-  description = "Linux OS distribution type for TFE EC2 instance. Choose from `al2023`, `ubuntu`, `rhel`, `centos`."
+  description = "Linux OS distribution type for TFE EC2 instance. Choose from `al2023`, `ubuntu`, `rhel` (RHEL9), `rhel10` (RHEL 10), `centos`."
   default     = "ubuntu"
 
   validation {
-    condition     = contains(["ubuntu", "rhel", "al2023", "centos"], var.ec2_os_distro)
-    error_message = "Valid values are `ubuntu`, `rhel`, `al2023`, or `centos`."
+    condition     = contains(["ubuntu", "rhel", "rhel10", "al2023", "centos"], var.ec2_os_distro)
+    error_message = "Valid values are `ubuntu`, `rhel`, `rhel10`, `al2023`, or `centos`."
   }
 
   validation {


### PR DESCRIPTION
## Description
This PR adds RHEL 10 support and fixes a bug preventing Podman installation on RHEL 9. The changes include:
- Fixed Podman installation bug on RHEL 9
- Added RHEL 10(rhel10) as a supported `ec2_os_distro` value
- Updated tfvar.example to explain rhel10 value support
- Added documentation for Podman and Docker setup on RHEL 10

## Related issue
N/A

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] This change requires a documentation update

## How has this been tested?
The following test scenarios were executed to verify the changes:
- **RHEL 9 + Docker**: Successfully deployed and verified Docker container runtime
- **RHEL 9 + Podman**: Successfully deployed and verified Podman installation (bug fix validated)
- **RHEL 10 + Podman**: Successfully deployed and verified Podman on the new RHEL 10 distribution

All tests passed without issues, confirming both the bug fix and new RHEL 10 support functionality.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional notes
- The RHEL 9 Podman installation bug was blocking users from deploying with Podman on RHEL 9
- RHEL 10 support extends the platform compatibility for future deployments