### PR TITLE
feat(user_data): add stop_grace_period to tfe docker-compose service

### DIFF
--- a/templates/tfe_user_data.sh.tpl
+++ b/templates/tfe_user_data.sh.tpl
@@ -210,6 +210,7 @@ services:
   tfe:
     image: ${tfe_image_repository_url}/${tfe_image_name}:${tfe_image_tag}
     restart: unless-stopped
+    stop_grace_period: 30s
     environment:
       # Application settings
       TFE_HOSTNAME: ${tfe_hostname}


### PR DESCRIPTION
## Description
Add `stop_grace_period: 30s` to the `tfe` service in the docker-compose configuration rendered by `templates/tfe_user_data.sh.tpl`. Single-line insertion after the existing `restart: unless-stopped` directive.

## Related issue
Closes #59

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested
The generated docker-compose YAML will include:
```yaml
    restart: unless-stopped
    stop_grace_period: 30s
```
Gives TFE 30 seconds to shut down gracefully on `docker compose stop` or `docker compose down`, replacing the default 10-second timeout.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] Change is limited to one line in one template file — no variable, output, or README changes required